### PR TITLE
Eliminating allocations with ODEProblem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/AccretionFormulae/orbit-discovery.jl
+++ b/src/AccretionFormulae/orbit-discovery.jl
@@ -16,7 +16,7 @@ end
 
 function measure_stability(m::AbstractMetricParams{T}, r, vϕ; tracer_args...) where {T}
     sol = trace_single_orbit(m, r, vϕ; tracer_args...)
-    rs = selectdim(sol, 1, 6)
+    rs = selectdim(sol, 1, 2)
     Qs(rs)
 end
 

--- a/src/AccretionGeometry/geometry.jl
+++ b/src/AccretionGeometry/geometry.jl
@@ -10,16 +10,8 @@ function to_cartesian(r, ϕ, θ)
     (r * sinϕ * cos(θ), r * sinϕ * sin(θ), r * cos(ϕ))
 end
 
-function cartesian_line_element(u::ArrayPartition{F,T}, integrator) where {F,T}
-    (to_cartesian(integrator.uprev.x[2]), to_cartesian(u.x[2]))
-end
-
 function cartesian_line_element(u, integrator)
     (to_cartesian(integrator.uprev), to_cartesian(u))
-end
-
-function line_element(u::ArrayPartition{F,T}, integrator) where {F,T}
-    @inbounds (@view(integrator.uprev.x[2][2:4]), @view(u.x[2][2:4]))
 end
 
 function line_element(u, integrator)

--- a/src/FirstOrderMethods/FirstOrderMethods.jl
+++ b/src/FirstOrderMethods/FirstOrderMethods.jl
@@ -24,7 +24,8 @@ import ..GeodesicTracer:
     metric_callback,
     create_callback_set,
     constrain,
-    alpha_beta_to_vel
+    alpha_beta_to_vel,
+    ensure_chart_callback
 
 abstract type AbstractFirstOrderMetricParams{T} <: AbstractMetricParams{T} end
 

--- a/src/FirstOrderMethods/callbacks.jl
+++ b/src/FirstOrderMethods/callbacks.jl
@@ -1,12 +1,3 @@
-function ensure_domain(
-    m::AbstractFirstOrderMetricParams{T},
-    closest_approach,
-    effective_infinity,
-) where {T}
-    min_r = inner_radius(m)
-    (u, λ, integrator) -> u[2] ≤ min_r * closest_approach || u[2] > effective_infinity
-end
-
 function flip_radial_sign!(integrator)
     p = integrator.p
     integrator.p = @set p.r = -p.r

--- a/src/FirstOrderMethods/implementation.jl
+++ b/src/FirstOrderMethods/implementation.jl
@@ -29,10 +29,7 @@ function metric_callback(
     effective_infinity,
 ) where {T}
     (
-        DiscreteCallback(
-            ensure_domain(m, closest_approach, effective_infinity),
-            terminate!,
-        ),
+        ensure_chart_callback(m, closest_approach, effective_infinity),
         DiscreteCallback(radial_negative_check(m), flip_radial_sign!),
         DiscreteCallback(angular_negative_check(m), flip_angular_sign!),
     )

--- a/src/GeodesicTracer/callbacks.jl
+++ b/src/GeodesicTracer/callbacks.jl
@@ -6,7 +6,7 @@ function metric_callback(
     min_r = inner_radius(m)
     # terminate integration if we come within 1% of the black hole radius
     DiscreteCallback(
-        (u, λ, integrator) -> u[6] ≤ min_r * closest_approach || u[6] > effective_infinity,
+        (u, λ, integrator) -> u[2] ≤ min_r * closest_approach || u[2] > effective_infinity,
         terminate!,
     )
 end

--- a/src/GeodesicTracer/callbacks.jl
+++ b/src/GeodesicTracer/callbacks.jl
@@ -1,14 +1,22 @@
-function metric_callback(
+@inline function ensure_chart_callback(
     m::AbstractMetricParams{T},
     closest_approach,
     effective_infinity,
 ) where {T}
     min_r = inner_radius(m)
-    # terminate integration if we come within 1% of the black hole radius
+    # terminate integration if we come within some % of the black hole radius
     DiscreteCallback(
         (u, λ, integrator) -> u[2] ≤ min_r * closest_approach || u[2] > effective_infinity,
         terminate!,
     )
+end
+
+function metric_callback(
+    m::AbstractMetricParams{T},
+    closest_approach,
+    effective_infinity,
+) where {T}
+    ensure_chart_callback(m, closest_approach, effective_infinity)
 end
 
 function create_callback_set(

--- a/src/GeodesicTracer/problem.jl
+++ b/src/GeodesicTracer/problem.jl
@@ -4,8 +4,12 @@ function integrator_problem(
     vel::StaticVector{S,T},
     time_domain,
 ) where {S,T}
-    SecondOrderODEProblem{false}(vel, pos, time_domain, m) do v, u, p, λ
-        SVector{S,T}(geodesic_eq(p, u, v)...)
+    u_init = vcat(pos, vel)
+    ODEProblem{false}(u_init, time_domain) do u, p, λ
+        @inbounds let x = @view(u[1:4]), v = @view(u[5:8])
+            dv = SVector{4}(geodesic_eq(m, x, v))
+            SVector{8}(v[1], v[2], v[3], v[4], dv[1], dv[2], dv[3], dv[4])
+        end
     end
 end
 
@@ -15,7 +19,13 @@ function integrator_problem(
     vel::AbstractVector{T},
     time_domain,
 ) where {T}
-    SecondOrderODEProblem{true}(vel, pos, time_domain, m) do dv, v, u, p, λ
-        dv .= geodesic_eq(p, u, v)
+    u_init = vcat(pos, vel)
+    ODEProblem{true}(u_init, time_domain) do du, u, p, λ
+        @inbounds let x = @view(u[1:4]), v = @view(u[5:8])
+            dv = SVector{4}(geodesic_eq(m, x, v))
+            
+            du[1:4] = v
+            du[5:8] = dv
+        end
     end
 end

--- a/src/GeodesicTracer/problem.jl
+++ b/src/GeodesicTracer/problem.jl
@@ -23,7 +23,7 @@ function integrator_problem(
     ODEProblem{true}(u_init, time_domain) do du, u, p, λ
         @inbounds let x = @view(u[1:4]), v = @view(u[5:8])
             dv = SVector{4}(geodesic_eq(m, x, v))
-            
+
             du[1:4] = v
             du[5:8] = dv
         end

--- a/src/GradusBase/geodesic-solutions.jl
+++ b/src/GradusBase/geodesic-solutions.jl
@@ -34,8 +34,8 @@ function get_endpoint(
     sol::SciMLBase.AbstractODESolution{T,N,S},
 ) where {T,N,S}
     us, ts, _ = unpack_solution(sol)
-    u = us[end].x[2]
-    v = us[end].x[1]
+    u = us[end][1:4]
+    v = us[end][5:8]
     t = ts[end]
     GeodesicPoint(sol.retcode, t, u, v)
 end

--- a/test/smoke-tests/rendergeodesics.jl
+++ b/test/smoke-tests/rendergeodesics.jl
@@ -34,7 +34,7 @@ using Test, Gradus, StaticArrays
             [BoyerLindquistAD(), JohannsenAD(), BoyerLindquistFO(), MorrisThorneAD()],
             # expectation values for the sum of the image
             # last computed 24/04/2022: closest approach reduced to 1% RS
-            [87044.35873353803, 87056.09986648493, 81500.87198429636, 36218.59567455362],
+            [87197.374065253, 87069.09711527612, 81500.87198429636, 36314.983726028615],
         )
             img = rendergeodesics(
                 m,


### PR DESCRIPTION
Converted the second order integrator to use `ODEProblem` instead of `SecondOrderODEProblem`, as this vastly reduces the number of allocations made during integration.

This closes #10.

Consequently, however, we no-longer have access to the second order integration methods, such as the Nystrom integrators. We weren't using them, and they didn't benchmark particularly well, so I guess that's not a huge loss, but something to bear in mind.

Example code:
```julia
using Gradus, StaticArrays
m = BoyerLindquistAD(M=1.0, a=0.998)

u = @SVector [0.0, 1000.0, deg2rad(90), 0.0]

img = @time rendergeodesics(
    m, u, 2000.0; 
    abstol=1e-9, reltol=1e-9,
    image_width=200 * 4, 
    image_height=200 * 4, 
    fov_factor=13.0 * 4,
    verbose = true
)
```

Before #17 and this PR:
```
55.465356 seconds (1.47 G allocations: 51.276 GiB, 33.66% gc time, 4.16% compilation time)
```

After:
```
14.672502 seconds (15.57 M allocations: 5.439 GiB)
```

👍 