### PR TITLE
New example: concentric rings

### DIFF
--- a/docs/src/overview/examples.md
+++ b/docs/src/overview/examples.md
@@ -217,14 +217,14 @@ p
 
 ## Event horizons and naked singularities
 
-Here is an example of how to use [`Gradus.event_horizon`](@ref) to plot the shape of an event horizon in two dimensions. In the case of a naked singularity, as with the certain parameters combinations in the [`JohannsenPsaltisAD`](@ref) metric, we see a disconnected region in the plot.
+Here is an example of how to use [`eventhorizon`](@ref) to plot the shape of an event horizon in two dimensions. In the case of a naked singularity, as with the certain parameters combinations in the [`JohannsenPsaltisAD`](@ref) metric, we see a disconnected region in the plot.
 
 ```@example env
 using Gradus
 using Plots
 
 function draw_horizon(p, m)
-    rs, θs = Gradus.event_horizon(m, resolution = 200)
+    rs, θs = eventhorizon(m, resolution = 200)
     radius = rs
 
     x = @. radius * sin(θs)
@@ -304,5 +304,38 @@ for a in [0.0, 0.25, 0.5, 0.75, 0.9, 0.998]
     mask = @. (ctf.gstar > 0.001) & (ctf.gstar < 0.999)
     @views plot!(p, ctf.gstar[mask], ctf.f[mask])
 end
+p
+```
+
+## Concentric rings
+
+Recreating Figure 2 from Johannsen and Psaltis (2012, II):
+
+```@example env
+using Gradus
+using StaticArrays
+using Plots
+
+# their papers has a=-a
+m = BoyerLindquistAD(M=1.0, a=-0.4)
+u = @SVector [0.0, 1000, acos(0.25), 0.0]
+d = GeometricThinDisc(0.0, 100.0, π / 2)
+
+radii = 2.6:1.0:7.6
+
+p = plot(
+    aspect_ratio = 1,
+    legend = false,
+)
+
+# crosshair on origin
+hline!(p, [0.0], color = :black, linestyle=:dash)
+vline!(p, [0.0], color = :black, linestyle=:dash)
+
+for r in radii
+    α, β = impact_parameters_for_radius(m, u, d, r, N=100)
+    plot!(p, α, β)
+end
+
 p
 ```

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -34,6 +34,7 @@ import .GradusBase:
     metric_params,
     metric,
     getgeodesicpoint,
+    getgeodesicpoints,
     GeodesicPoint,
     AbstractGeodesicPoint,
     vector_to_local_sky,
@@ -49,6 +50,7 @@ import .GradusBase:
 
 export AbstractMetricParams,
     getgeodesicpoint,
+    getgeodesicpoints,
     GeodesicPoint,
     AbstractGeodesicPoint,
     AbstractMetricParams,

--- a/src/GradusBase/GradusBase.jl
+++ b/src/GradusBase/GradusBase.jl
@@ -12,11 +12,11 @@ import ..Gradus
 using DocStringExtensions
 
 include("metric-params.jl")
-include("physical-quantities.jl")
 include("geodesic-solutions.jl")
 include("geometry.jl")
+include("physical-quantities.jl")
 
-export AbstractMetricParams, metric_params, metric, getgeodesicpoint
+export AbstractMetricParams, metric_params, metric, getgeodesicpoint, getgeodesicpoints
 GeodesicPoint,
 AbstractGeodesicPoint,
 vector_to_local_sky,

--- a/src/GradusBase/geodesic-solutions.jl
+++ b/src/GradusBase/geodesic-solutions.jl
@@ -48,10 +48,10 @@ information relevant to start and endpoint of the integration. To keep the full 
 encouraged to use the `SciMLBase.AbstractODESolution` directly.
 """
 function getgeodesicpoint(
-    m::AbstractMetricParams{T},
+    _::AbstractMetricParams{T},
     sol::SciMLBase.AbstractODESolution{T,N,S},
 ) where {T,N,S}
-    @inbounds begin
+    @inbounds @views begin
         us, ts, _ = unpack_solution(sol)
 
         u_start = SVector{4,T}(us[1][1:4])
@@ -63,6 +63,30 @@ function getgeodesicpoint(
         t_end = ts[end]
 
         GeodesicPoint(sol.retcode, t_start, t_end, u_start, u_end, v_start, v_end)
+    end
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Unpacks each point in the solution, similar to [`getgeodesicpoint`](@ref) but returns an 
+array of [`GeodesicPoint`](@ref).
+"""
+function getgeodesicpoints(
+    _::AbstractMetricParams{T},
+    sol::SciMLBase.AbstractODESolution{T,N,S},
+) where {T,N,S}
+    us, ts, _ = unpack_solution(sol)
+    @inbounds @views begin
+        u_start = SVector{4,T}(us[1][1:4])
+        v_start = SVector{4,T}(us[1][5:8])
+        t_start = ts[1]
+        map(eachindex(us)) do i
+            ui = SVector{4,T}(us[i][1:4])
+            vi = SVector{4,T}(us[i][5:8])
+            ti = ts[i]
+            GeodesicPoint(sol.retcode, t_start, ti, u_start, ui, v_start, vi)
+        end
     end
 end
 

--- a/src/GradusBase/physical-quantities.jl
+++ b/src/GradusBase/physical-quantities.jl
@@ -20,6 +20,7 @@ function E(metric::AbstractMatrix{T}, v) where {T}
     T(@inbounds -(metric[1, 1] * v[1] + metric[1, 4] * v[4]))
 end
 E(m::AbstractMetricParams{T}, u, v) where {T} = E(metric(m, u), v)
+E(m::AbstractMetricParams{T}, gp::AbstractGeodesicPoint) where {T} = E(m, gp.u2, gp.v2)
 
 
 """
@@ -35,3 +36,4 @@ function Lz(metric::AbstractMatrix{T}, v) where {T}
     T(@inbounds metric[4, 4] * v[4] + metric[1, 4] * v[1])
 end
 Lz(m::AbstractMetricParams{T}, u, v) where {T} = Lz(metric(m, u), v)
+Lz(m::AbstractMetricParams{T}, gp::AbstractGeodesicPoint) where {T} = Lz(m, gp.u2, gp.v2)

--- a/src/orbits/emission-radii.jl
+++ b/src/orbits/emission-radii.jl
@@ -26,12 +26,13 @@ function integrate_single_geodesic(
     d::AbstractAccretionDisc,
     rₒ,
     θₒ;
+    max_time = 2e3,
     kwargs...,
 )
     α = rₒ * cos(θₒ)
     β = rₒ * sin(θₒ)
     v = map_impact_parameters(m, u, α, β)
-    sol = tracegeodesics(m, u, v, d, (0.0, 2000.0); save_on = false, kwargs...)
+    sol = tracegeodesics(m, u, v, d, (0.0, max_time); save_on = false, kwargs...)
     getgeodesicpoint(m, sol)
 end
 

--- a/src/special-radii.jl
+++ b/src/special-radii.jl
@@ -100,7 +100,7 @@ function _event_horizon_condition(m, r, θ)
     g[5]^2 - g[1] * g[4]
 end
 
-function event_horizon(
+function eventhorizon(
     m::AbstractAutoDiffStaticAxisSymmetricParams{T};
     select = maximum,
     resolution::Int = 100,


### PR DESCRIPTION
Also corrected a function `event_horizon` to `eventhorizon` so that it actually gets exported, and added a new keyword for calculating impact parameters for a given radius, such that the maximum integration time may be set.