### PR TITLE
Tetrad basis and various fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/GradusBase/GradusBase.jl
+++ b/src/GradusBase/GradusBase.jl
@@ -3,7 +3,7 @@ module GradusBase
 import Parameters: @with_kw
 import SciMLBase
 import Base
-import StaticArrays: SVector, MMatrix
+import StaticArrays: SVector, MMatrix, SMatrix, @SVector
 import Tullio: @tullio
 
 # for doc bindings

--- a/src/accretion-geometry/discs.jl
+++ b/src/accretion-geometry/discs.jl
@@ -44,7 +44,8 @@ end
         if r < m.inner_radius || r > m.outer_radius
             return 1.0
         end
-        @SVector [r * sin(θ) * cos(ϕ), r * sin(θ) * sin(ϕ), r * cos(θ)]
+        sinθ = sin(θ)
+        @SVector [r * sinθ * cos(ϕ), r * sinθ * sin(ϕ), r * cos(θ)]
     end
     n = @SVector [T(0.0), cos(m.inclination), sin(m.inclination)]
     # project u into normal vector n

--- a/src/accretion-geometry/meshes.jl
+++ b/src/accretion-geometry/meshes.jl
@@ -14,7 +14,7 @@ function MeshAccretionGeometry(mesh)
     static_mesh = map(mesh) do triangle
         Tuple(SVector(p[1], p[2], p[3]) for p in triangle)
     end
-    MeshAccretionGeometry(static_mesh, bounding_box(mesh)...)
+    MeshAccretionGeometry(static_mesh, bounding_box(static_mesh)...)
 end
 
 # naive implementation

--- a/src/corona-to-disc/transfer-functions.jl
+++ b/src/corona-to-disc/transfer-functions.jl
@@ -1,6 +1,14 @@
-function bin_transfer_function(time_delays, energy, flux; N = 300)
-    energy_bins = range(extrema(energy)..., N)
-    time_bins = range(extrema(time_delays)..., N)
+function bin_transfer_function(
+    time_delays,
+    energy,
+    flux;
+    N_E = 300,
+    N_t = 300,
+    energy_lims = extrema(energy),
+    time_lims = extrema(time_delays),
+)
+    energy_bins = range(energy_lims..., N_E)
+    time_bins = range(time_lims..., N_t)
 
     de = step(energy_bins)
     dt = step(time_bins)

--- a/src/metrics/boyer-lindquist-ad.jl
+++ b/src/metrics/boyer-lindquist-ad.jl
@@ -1,8 +1,8 @@
 module __BoyerLindquistAD
 using ..StaticArrays
 
-@inline Σ(r, a, θ) = r^2 + a^2 * cos(θ)^2
-@inline Δ(r, R, a) = r^2 - R * r + a^2
+@fastmath Σ(r, a, θ) = r^2 + a^2 * cos(θ)^2
+@fastmath Δ(r, R, a) = r^2 - R * r + a^2
 
 # the way this function must be defined is a little complex
 # but helps with type-stability

--- a/src/metrics/dilaton-axion-ad.jl
+++ b/src/metrics/dilaton-axion-ad.jl
@@ -5,7 +5,7 @@ García et al. (1995).
 module __DilatonAxionAD
 using ..StaticArrays
 
-@fastmath Σ(r, a, θ) = r^3 + a^2 * cos(θ)^2
+@fastmath Σ(r, a, θ) = r^2 + a^2 * cos(θ)^2
 @fastmath Δ(r, a, rg) = r^2 - 2rg * r + a^2
 @fastmath A(r, a, Δ, θ) = (r^2 + a^2)^2 - a^2 * Δ * sin(θ)^2
 

--- a/src/metrics/dilaton-axion-ad.jl
+++ b/src/metrics/dilaton-axion-ad.jl
@@ -5,15 +5,15 @@ García et al. (1995).
 module __DilatonAxionAD
 using ..StaticArrays
 
-Σ(r, a, θ) = r^2 + a^2 * cos(θ)^2
-Δ(r, a, rg) = r^2 - 2rg * r + a^2
-A(r, a, Δ, θ) = (r^2 + a^2)^2 - a^2 * Δ * sin(θ)^2
+@fastmath Σ(r, a, θ) = r^3 + a^2 * cos(θ)^2
+@fastmath Δ(r, a, rg) = r^2 - 2rg * r + a^2
+@fastmath A(r, a, Δ, θ) = (r^2 + a^2)^2 - a^2 * Δ * sin(θ)^2
 
-W(βab, θ, βa) = 1 + (βab * (2 * cos(θ) - βab) + βa^2) * csc(θ)^2
-Σ̂(Σ, β, b, r, βb, a, θ, rg) = Σ - (β^2 + 2b * r) + rg^2 * βb * (βb - 2 * (a / rg) * cos(θ))
-Δ̂(Δ, β, b, r, βb, rg) = Δ - (β^2 + 2b * r) - rg * (rg + 2b) * βb^2
-Â(δ, a, Δ̂, W, θ) = δ^2 - a^2 * Δ̂ * W^2 * sin(θ)^2
-δ(r, b, a) = r^2 - 2b * r + a^2
+@fastmath W(βab, θ, βa) = 1 + (βab * (2 * cos(θ) - βab) + βa^2) * csc(θ)^2
+@fastmath Σ̂(Σ, β, b, r, βb, a, θ, rg) = Σ - (β^2 + 2b * r) + rg^2 * βb * (βb - 2 * (a / rg) * cos(θ))
+@fastmath Δ̂(Δ, β, b, r, βb, rg) = Δ - (β^2 + 2b * r) - rg * (rg + 2b) * βb^2
+@fastmath Â(δ, a, Δ̂, W, θ) = δ^2 - a^2 * Δ̂ * W^2 * sin(θ)^2
+@fastmath δ(r, b, a) = r^2 - 2b * r + a^2
 
 @fastmath function metric_components(M, a, β, b, rθ)
     (r, θ) = rθ

--- a/src/metrics/johannsen-ad.jl
+++ b/src/metrics/johannsen-ad.jl
@@ -1,13 +1,13 @@
 module __JohannsenAD
 using ..StaticArrays
 
-@inline f(M, r, ϵ3) = ϵ3 * M^3 / r
-@inline Σ(r, a, θ, M, ϵ3) = r^2 + a^2 * cos(θ)^2 + f(M, r, ϵ3)
-@inline Δ(r, M, a) = r^2 - 2M * r + a^2
+@fastmath f(M, r, ϵ3) = ϵ3 * M^3 / r
+@fastmath Σ(r, a, θ, M, ϵ3) = r^2 + a^2 * cos(θ)^2 + f(M, r, ϵ3)
+@fastmath Δ(r, M, a) = r^2 - 2M * r + a^2
 
-@inline A₁(M, r, α13) = 1 + α13 * (M / r)^3
-@inline A₂(M, r, α22) = 1 + α22 * (M / r)^2
-@inline A₅(M, r, α52) = 1 + α52 * (M / r)^2
+@fastmath A₁(M, r, α13) = 1 + α13 * (M / r)^3
+@fastmath A₂(M, r, α22) = 1 + α22 * (M / r)^2
+@fastmath A₅(M, r, α52) = 1 + α52 * (M / r)^2
 
 @fastmath function metric_components(m, rθ)
     (r, θ) = rθ

--- a/src/metrics/johannsen-psaltis-ad.jl
+++ b/src/metrics/johannsen-psaltis-ad.jl
@@ -1,9 +1,9 @@
 module __JohannsenPsaltisAD
 using ..StaticArrays
 
-@inline h(r, M, ϵ3, Σ) = ϵ3 * M^3 * r / Σ^2
-@inline Σ(r, a, θ) = r^2 + a^2 * cos(θ)^2
-@inline Δ(r, M, a) = r^2 - 2M * r + a^2
+@fastmath h(r, M, ϵ3, Σ) = ϵ3 * M^3 * r / Σ^2
+@fastmath Σ(r, a, θ) = r^2 + a^2 * cos(θ)^2
+@fastmath Δ(r, M, a) = r^2 - 2M * r + a^2
 
 @fastmath function metric_components(M, a, ϵ3, rθ)
     (r, θ) = rθ

--- a/src/metrics/kerr-refractive-ad.jl
+++ b/src/metrics/kerr-refractive-ad.jl
@@ -1,8 +1,8 @@
 module __KerrRefractiveAD
 using ..StaticArrays
 
-@inline Σ(r, a, θ) = r^2 + a^2 * cos(θ)^2
-@inline Δ(r, R, a) = r^2 - R * r + a^2
+@fastmath Σ(r, a, θ) = r^2 + a^2 * cos(θ)^2
+@fastmath Δ(r, R, a) = r^2 - R * r + a^2
 
 @fastmath function metric_components(M, a, n, corona_radius, rθ)
     (r, θ) = rθ

--- a/src/metrics/morris-thorne-ad.jl
+++ b/src/metrics/morris-thorne-ad.jl
@@ -1,5 +1,6 @@
 module __MorrisThorneAD
 using ..StaticArrays
+
 @fastmath function metric_components(b, lθ)
     (l, θ) = lθ
 

--- a/src/orbits/circular-orbits.jl
+++ b/src/orbits/circular-orbits.jl
@@ -7,7 +7,7 @@ import ..Gradus:
     inverse_metric_components
 
 function Ω(m::AbstractAutoDiffStaticAxisSymmetricParams{T}, rθ, pos) where {T}
-    jacs = metric_jacobian(m, rθ)
+    _, jacs = metric_jacobian(m, rθ)
     ∂rg = jacs[:, 1]
 
     Δ = √(∂rg[5]^2 - ∂rg[1] * ∂rg[4])

--- a/src/orbits/emission-radii.jl
+++ b/src/orbits/emission-radii.jl
@@ -77,6 +77,7 @@ function redshift_ratio(
     max_time,
     αs,
     βs;
+    redshift_pf = Gradus.ConstPointFunctions.redshift,
     kwargs...,
 )
     velfunc(i) = map_impact_parameters(m, u, αs[i], βs[i])
@@ -92,11 +93,22 @@ function redshift_ratio(
     )
     map(simsols) do sol
         gp = getgeodesicpoint(m, sol)
-        Gradus.ConstPointFunctions.redshift(m, gp, max_time)
+        redshift_pf(m, gp, max_time)
     end
 end
 
-function jacobian_∂αβ_∂gr(m, u, d, max_time, gs, αs, βs; order = 3, kwargs...)
+function jacobian_∂αβ_∂gr(
+    m,
+    u,
+    d,
+    max_time,
+    gs,
+    αs,
+    βs;
+    order = 3,
+    redshift_pf = Gradus.ConstPointFunctions.redshift,
+    kwargs...,
+)
     gmin, gmax = extrema(gs)
     gstar(g) = (g - gmin) / (gmax - gmin)
 
@@ -104,7 +116,7 @@ function jacobian_∂αβ_∂gr(m, u, d, max_time, gs, αs, βs; order = 3, kwar
         v = map_impact_parameters(m, u, α, β)
         sol = tracegeodesics(m, u, v, d, (0.0, max_time); save_on = false, kwargs...)
         gp = getgeodesicpoint(m, sol)
-        g = Gradus.ConstPointFunctions.redshift(m, gp, 2000.0)
+        g = redshift_pf(m, gp, 2000.0)
         @SVector [gp.u2[2], gstar(g)]
     end
 
@@ -140,12 +152,22 @@ function cunningham_transfer_function(
     max_time;
     num_points = 1000,
     finite_diff_order = 3,
+    redshift_pf::PointFunction = Gradus.ConstPointFunctions.redshift,
     tracer_kwargs...,
 )
     αs, βs =
         Gradus.impact_parameters_for_radius(m, u, d, rₑ; N = num_points, tracer_kwargs...)
 
-    gs = redshift_ratio(m, u, d, max_time, αs, βs; tracer_kwargs...)
+    gs = redshift_ratio(
+        m,
+        u,
+        d,
+        max_time,
+        αs,
+        βs;
+        redshift_pf = redshift_pf,
+        tracer_kwargs...,
+    )
     gstars = gstar(gs)
 
     js = jacobian_∂αβ_∂gr(
@@ -157,6 +179,7 @@ function cunningham_transfer_function(
         αs,
         βs;
         order = finite_diff_order,
+        redshift_pf = redshift_pf,
         tracer_kwargs...,
     )
 

--- a/src/tracing/method-implementations/auto-diff.jl
+++ b/src/tracing/method-implementations/auto-diff.jl
@@ -262,7 +262,7 @@ function metric_jacobian(m::AbstractAutoDiffStaticAxisSymmetricParams, rθ)
     f = x -> metric_components(m, x)
     T = typeof(ForwardDiff.Tag(f, eltype(rθ)))
     ydual = ForwardDiff.static_dual_eval(T, f, rθ)
-    ForwardDiff.value.(T,ydual), ForwardDiff.extract_jacobian(T, ydual, rθ)
+    ForwardDiff.value.(T, ydual), ForwardDiff.extract_jacobian(T, ydual, rθ)
 end
 
 @inbounds function geodesic_eq(

--- a/src/tracing/tracing.jl
+++ b/src/tracing/tracing.jl
@@ -69,9 +69,10 @@ function integrator_problem(
 ) where {S,T}
     u_init = vcat(pos, vel)
     ODEProblem{false}(u_init, time_domain) do u, p, λ
-        @inbounds let x = @view(u[1:4]), v = @view(u[5:8])
+        @inbounds let x = SVector{4}(@view(u[1:4])), v = SVector{4}(@view(u[5:8]))
             dv = SVector{4}(geodesic_eq(m, x, v))
-            SVector{8}(v[1], v[2], v[3], v[4], dv[1], dv[2], dv[3], dv[4])
+            # SVector{8}(v[1], v[2], v[3], v[4], dv[1], dv[2], dv[3], dv[4])
+            vcat(v, dv)
         end
     end
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/test/unit/gradusbase.geometry.jl
+++ b/test/unit/gradusbase.geometry.jl
@@ -1,0 +1,33 @@
+
+@testset "tetradframe" begin
+    all_metrics = (
+        # can't do first order yet since no four velocity
+        # BoyerLindquistFO(1.0, 0.998, 1.0),
+        # BoyerLindquistFO(1.0, -0.998, 1.0),
+        BoyerLindquistAD(1.0, 0.998),
+        BoyerLindquistAD(1.0, -0.998),
+        JohannsenAD(M = 1.0, a = 0.998, α13 = 1.0),
+        JohannsenAD(M = 1.0, a = 0.998, α22 = 1.0),
+        DilatonAxionAD(M = 1.0, a = 0.998, β = 0.2, b = 1.0),
+    )
+    radii = 5.0:0.8:10.0
+    angles = 0.1:0.5:2π
+    minkowski = @SMatrix [
+       -1.0 0.0 0.0 0.0 ;
+        0.0 1.0 0.0 0.0 ;
+        0.0 0.0 1.0 0.0 ;
+        0.0 0.0 0.0 1.0 
+    ]
+    for m in all_metrics, r in radii, θ in angles
+        u = @SVector([0.0, r, θ, 0.0])
+        v = Gradus.constrain_all(m, u, CircularOrbits.fourvelocity(m, r), 1.0)
+
+        # function that we are testing
+        M = GradusBase.tetradframe(m, u, v)
+
+        m_mat = Gradus.metric(m, u)
+        @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
+        # ensure it gives minkowski
+        @test isapprox(res, minkowski, atol=1e-13)
+    end
+end


### PR DESCRIPTION
Fixed the Gram-Schmidt implementation, which now correctly gives tetrad basis that reduces to Minkowski, so we can use it to map angles from local to global frame.

Also addresses #50 with a small fix.

Various other minor API changes and fixes, and more unit tests.