### PR TITLE
Generic source-to-disc flux

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -151,6 +151,7 @@ include("corona-to-disc/sky-geometry.jl")
 include("corona-to-disc/corona-models.jl")
 include("corona-to-disc/disc-profiles.jl")
 include("corona-to-disc/transfer-functions.jl")
+include("corona-to-disc/flux-calculations.jl")
 
 include("metrics/boyer-lindquist-ad.jl")
 include("metrics/boyer-lindquist-fo.jl")

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -46,7 +46,14 @@ import .GradusBase:
     metric_type,
     metric_components,
     inverse_metric_components,
-    unpack_solution
+    unpack_solution,
+    dotproduct,
+    propernorm,
+    tetradframe,
+    lnrbasis,
+    lnrframe,
+    lowerindices,
+    raiseindices
 
 export AbstractMetricParams,
     getgeodesicpoint,
@@ -57,7 +64,14 @@ export AbstractMetricParams,
     constrain,
     inner_radius,
     metric_components,
-    inverse_metric_components
+    inverse_metric_components,
+    dotproduct,
+    propernorm,
+    tetradframe,
+    lnrbasis,
+    lnrframe,
+    lowerindices,
+    raiseindices
 
 """
     abstract type AbstractPointFunction

--- a/src/GradusBase/GradusBase.jl
+++ b/src/GradusBase/GradusBase.jl
@@ -1,10 +1,12 @@
 module GradusBase
 
-import Parameters: @with_kw
-import SciMLBase
 import Base
-import StaticArrays: SVector, MMatrix, SMatrix, @SVector
-import Tullio: @tullio
+import SciMLBase
+
+using Parameters: @with_kw
+using StaticArrays: SVector, MMatrix, SMatrix, @SVector
+using Tullio: @tullio
+using LinearAlgebra: norm, inv
 
 # for doc bindings
 import ..Gradus

--- a/src/GradusBase/GradusBase.jl
+++ b/src/GradusBase/GradusBase.jl
@@ -29,6 +29,13 @@ constrain,
 inner_radius,
 metric_type,
 metric_components,
-inverse_metric_components
+inverse_metric_components,
+dotproduct,
+propernorm,
+tetradframe,
+lnrbasis,
+lnrframe,
+lowerindices,
+raiseindices
 
 end # module

--- a/src/GradusBase/geometry.jl
+++ b/src/GradusBase/geometry.jl
@@ -50,22 +50,22 @@ tetradframe(m::AbstractMetricParams, u, v) = _tetradframe(metric(m, u), v)
 
 # TODO: this presupposes static and axis symmetric
 # tetrad with indices down: frame
-function lnrframe(m::AbstractMetricParams, u)
-    g = metric(m, u)
+function lnrframe(g)
     ω = -g[1, 4] / g[4, 4]
     v = @SVector [1.0, 0.0, 0.0, ω]
     _tetradframe(g, v)
 end
+lnrframe(m::AbstractMetricParams, u) = lnrframe(metric(m, u))
 
 # tetrad with indices up: basis
-function lnrbasis(m::AbstractMetricParams, u)
-    g = metric(m, u)
+function lnrbasis(g)
     ω = -g[1, 4] / g[4, 4]
     v = @SVector [-ω, 0.0, 0.0, 1.0]
     (vϕ, vr, vθ, vt) = _tetradframe(inv(g), v)
     # rearrange
     (vt, vr, vθ, vϕ)
 end
+lnrbasis(m::AbstractMetricParams, u) = lnrbasis(metric(m, u))
 
 lowerindices(g, v) = g * v
 lowerindices(m::AbstractMetricParams, u, v) = lowerindices(metric(m, u), v)

--- a/src/GradusBase/geometry.jl
+++ b/src/GradusBase/geometry.jl
@@ -2,8 +2,8 @@ function vector_to_local_sky(m::AbstractMetricParams, u, θ, ϕ)
     error("Not implemented for $(typeof(m))")
 end
 
-mdot(g, v1, v2) = @tullio r := g[i, j] * v1[i] * v2[j]
-mnorm(g, v) = mdot(g, v, v)
+dotproduct(g::AbstractMatrix, v1, v2) = @tullio r := g[i, j] * v1[i] * v2[j]
+propernorm(g::AbstractMatrix, v) = dotproduct(g, v, v)
 
 """
     mproject(g, v, u)
@@ -11,7 +11,7 @@ mnorm(g, v) = mdot(g, v, v)
 Project vector `v` onto `u` with metric `g`. Optional first argument may be
 [`AbstractMetricParams`](@ref) for more optimized methods, which fallback to an einsum.
 """
-mproject(g, v, u) = mdot(g, v, u) / mnorm(g, u)
+mproject(g, v, u) = dotproduct(g, v, u) / propernorm(g, u)
 
 function projectbasis(g, basis, v)
     s = zero(SVector{4,Float64})
@@ -30,13 +30,13 @@ function gramschmidt(v, basis, g; tol = 4eps(Float64))
     end
 
     v = v .- p
-    vnorm = √abs(mnorm(g, v))
+    vnorm = √abs(propernorm(g, v))
     v / vnorm
 end
 
 # TODO: this presupposes static and axis symmetric
-@inline function _tetradframe(g, v)
-    vt = v ./ √abs(mnorm(g, v))
+@inline function tetradframe(g::AbstractMatrix, v)
+    vt = v ./ √abs(propernorm(g, v))
     # start procedure with ϕ, which has zero for r and θ
     vϕ = gramschmidt(@SVector[1.0, 0.0, 0.0, 1.0], (vt,), g)
     # then do r, which has zero for θ
@@ -46,29 +46,29 @@ end
     (vt, vr, vθ, vϕ)
 end
 
-tetradframe(m::AbstractMetricParams, u, v) = _tetradframe(metric(m, u), v)
+tetradframe(m::AbstractMetricParams, u, v) = tetradframe(metric(m, u), v)
 
 # TODO: this presupposes static and axis symmetric
 # tetrad with indices down: frame
-function lnrframe(g)
+function lnrframe(g::AbstractMatrix)
     ω = -g[1, 4] / g[4, 4]
     v = @SVector [1.0, 0.0, 0.0, ω]
-    _tetradframe(g, v)
+    tetradframe(g, v)
 end
 lnrframe(m::AbstractMetricParams, u) = lnrframe(metric(m, u))
 
 # tetrad with indices up: basis
-function lnrbasis(g)
+function lnrbasis(g::AbstractMatrix)
     ω = -g[1, 4] / g[4, 4]
     v = @SVector [-ω, 0.0, 0.0, 1.0]
-    (vϕ, vr, vθ, vt) = _tetradframe(inv(g), v)
+    (vϕ, vr, vθ, vt) = tetradframe(inv(g), v)
     # rearrange
     (vt, vr, vθ, vϕ)
 end
 lnrbasis(m::AbstractMetricParams, u) = lnrbasis(metric(m, u))
 
-lowerindices(g, v) = g * v
+lowerindices(g::AbstractMatrix, v) = g * v
 lowerindices(m::AbstractMetricParams, u, v) = lowerindices(metric(m, u), v)
 
-raiseindices(ginv, v) = ginv * v
+raiseindices(ginv::AbstractMatrix, v) = ginv * v
 raiseindices(m::AbstractMetricParams, u, v) = raiseindices(inv(metric(m, u)), v)

--- a/src/corona-to-disc/corona-models.jl
+++ b/src/corona-to-disc/corona-models.jl
@@ -29,4 +29,15 @@ function sample_velocity(
     end
 end
 
+function source_velocity(m::AbstractMetricParams, model::AbstractCoronaModel)
+    error("Not implemented for $(typeof(model)).")
+end
+
+function source_velocity(m::AbstractMetricParams, model::LampPostModel)
+    # stationary source
+    rθ = @SVector[model.h, model.θ]
+    gcomp = metric_components(m, rθ)
+    inv(√(-gcomp[1])) * @SVector[1.0, 0.0, 0.0, 0.0]
+end
+
 export LampPostModel

--- a/src/corona-to-disc/flux-calculations.jl
+++ b/src/corona-to-disc/flux-calculations.jl
@@ -6,7 +6,7 @@ Calculate Lorentz factor in LNRF of `u`.
 function lorentz_factor(g::AbstractMatrix, isco_r, u, v)
     frame = Gradus.GradusBase.lnrbasis(g)
     B = reduce(hcat, frame)
-    denom = B[:, 1] ⋅ u_disc
+    denom = B[:, 1] ⋅ v 
 
     𝒱ϕ = (B[:, 4] ⋅ v) / denom
 
@@ -73,5 +73,7 @@ function flux_source_to_disc(
         # total reflected flux 
         g_sd^(1 + α) * E_d^(-α) * dA * f_sd / γ
     end
-    map(flux, enumerate(sd_points))
+    map(flux, enumerate(vdp.geodesic_points))
 end
+
+export flux_source_to_disc

--- a/src/corona-to-disc/flux-calculations.jl
+++ b/src/corona-to-disc/flux-calculations.jl
@@ -18,13 +18,15 @@ function lorentz_factor(g::AbstractMatrix, isco_r, u, v)
     end
 end
 
-flux_source_to_disc(
+function flux_source_to_disc(
     m::AbstractMetricParams,
     model::AbstractCoronaModel,
     vdp::AbstractDiscProfile,
-) = error(
-    "Not implemented for metric $(typeof(m)) with model $(typeof(model)) and disc profile $(typeof(vdp)).",
 )
+    error(
+        "Not implemented for metric $(typeof(m)) with model $(typeof(model)) and disc profile $(typeof(vdp)).",
+    )
+end
 
 function flux_source_to_disc(
     m::AbstractMetricParams,

--- a/src/corona-to-disc/flux-calculations.jl
+++ b/src/corona-to-disc/flux-calculations.jl
@@ -1,0 +1,75 @@
+"""
+    lorentz_factor(g::AbstractMatrix, isco, u, v) 
+
+Calculate Lorentz factor in LNRF of `u`.
+"""
+function lorentz_factor(g::AbstractMatrix, isco_r, u, v)
+    frame = Gradus.GradusBase.lnrbasis(g)
+    B = reduce(hcat, frame)
+    denom = B[:, 1] ⋅ u_disc
+
+    𝒱ϕ = (B[:, 4] ⋅ v) / denom
+
+    if u[2] < isco_r
+        𝒱r = (B[:, 2] ⋅ v) / denom
+        inv(√(1 - 𝒱r^2 - 𝒱ϕ^2))
+    else
+        inv(√(1 - 𝒱ϕ^2))
+    end
+end
+
+flux_source_to_disc(
+    m::AbstractMetricParams,
+    model::AbstractCoronaModel,
+    vdp::AbstractDiscProfile,
+) = error(
+    "Not implemented for metric $(typeof(m)) with model $(typeof(model)) and disc profile $(typeof(vdp)).",
+)
+
+function flux_source_to_disc(
+    m::AbstractMetricParams,
+    model::LampPostModel,
+    vdp::VoronoiDiscProfile;
+    α = 1.0,
+)
+    v_source = source_velocity(m, model)
+
+    intensity = inv.(getareas(vdp))
+    total_intensity = sum(intensity)
+
+    isco_r = isco(m)
+    intp = interpolate_plunging_velocities(m)
+
+    disc_velocity(r) =
+        if r < isco_r
+            vtemp = intp(r)
+            @SVector [vtemp[1], -vtemp[2], vtemp[3], vtemp[4]]
+        else
+            CircularOrbits.fourvelocity(m, r)
+        end
+
+    flux = args -> begin
+        (i, gp) = args
+        g_1 = metric(m, gp.u1)
+        g_2 = metric(m, gp.u2)
+
+        # energy at source
+        @tullio E_s := -g_1[i, j] * gp.v1[i] * v_source[j]
+
+        # energy at disc
+        v_disc = disc_velocity(gp.u2[2])
+        @tullio E_d := -g_2[i, j] * gp.v2[i] * v_disc[j]
+
+        # relative redshift source to disc
+        g_sd = E_d / E_s
+
+        # area element
+        dA = inv(√(g_2[2, 2] * g_2[4, 4]))
+
+        γ = lorentz_factor(g_2, isco_r, gp.u2, v_disc)
+        f_sd = intensity[i] / total_intensity
+        # total reflected flux 
+        g_sd^(1 + α) * E_d^(-α) * dA * f_sd / γ
+    end
+    map(flux, enumerate(sd_points))
+end

--- a/src/corona-to-disc/transfer-functions.jl
+++ b/src/corona-to-disc/transfer-functions.jl
@@ -18,7 +18,7 @@ function bin_transfer_function(
         e_mask = @. (e ≤ energy) & (energy < (e + de))
         sub_flux = @views(flux[t_mask.&e_mask])
         if length(sub_flux) > 0
-            sum(sub_flux)
+            sum(sub_flux) / (dt * de)
         else
             NaN
         end

--- a/src/metrics/dilaton-axion-ad.jl
+++ b/src/metrics/dilaton-axion-ad.jl
@@ -10,7 +10,8 @@ using ..StaticArrays
 @fastmath A(r, a, Δ, θ) = (r^2 + a^2)^2 - a^2 * Δ * sin(θ)^2
 
 @fastmath W(βab, θ, βa) = 1 + (βab * (2 * cos(θ) - βab) + βa^2) * csc(θ)^2
-@fastmath Σ̂(Σ, β, b, r, βb, a, θ, rg) = Σ - (β^2 + 2b * r) + rg^2 * βb * (βb - 2 * (a / rg) * cos(θ))
+@fastmath Σ̂(Σ, β, b, r, βb, a, θ, rg) =
+    Σ - (β^2 + 2b * r) + rg^2 * βb * (βb - 2 * (a / rg) * cos(θ))
 @fastmath Δ̂(Δ, β, b, r, βb, rg) = Δ - (β^2 + 2b * r) - rg * (rg + 2b) * βb^2
 @fastmath Â(δ, a, Δ̂, W, θ) = δ^2 - a^2 * Δ̂ * W^2 * sin(θ)^2
 @fastmath δ(r, b, a) = r^2 - 2b * r + a^2

--- a/src/orbits/circular-orbits.jl
+++ b/src/orbits/circular-orbits.jl
@@ -6,12 +6,16 @@ import ..Gradus:
     metric_jacobian,
     inverse_metric_components
 
-function Ω(m::AbstractAutoDiffStaticAxisSymmetricParams{T}, rθ, pos) where {T}
+function Ω(
+    m::AbstractAutoDiffStaticAxisSymmetricParams,
+    rθ;
+    contra_rotating = false,
+)
     _, jacs = metric_jacobian(m, rθ)
     ∂rg = jacs[:, 1]
 
     Δ = √(∂rg[5]^2 - ∂rg[1] * ∂rg[4])
-    if pos
+    if contra_rotating
         -(∂rg[5] + Δ) / ∂rg[4]
     else
         -(∂rg[5] - Δ) / ∂rg[4]
@@ -22,11 +26,12 @@ function __energy(g, Ωϕ)
     @inbounds -(g[1] + g[5] * Ωϕ) / √(-g[1] - 2g[5] * Ωϕ - g[4] * Ωϕ^2)
 end
 
-energy(m, r; contra_rotating = false) =
-    let rθ = @SVector([r, π / 2])
-        Ωϕ = Ω(m, rθ, contra_rotating)
-        __energy(metric_components(m, rθ), Ωϕ)
-    end
+function energy(m, rθ; contra_rotating = false)
+    Ωϕ = Ω(m, rθ; contra_rotating = contra_rotating)
+    __energy(metric_components(m, rθ), Ωϕ)
+end
+energy(m::AbstractAutoDiffStaticAxisSymmetricParams, r::Number; kwargs...) =
+    energy(m, @SVector([r, π / 2]); kwargs...)
 
 function __angmom(g, Ωϕ, prograde)
     @inbounds res = (g[5] + g[4] * Ωϕ) / √(-g[1] - 2g[5] * Ωϕ - g[4] * Ωϕ^2)
@@ -37,39 +42,39 @@ function __angmom(g, Ωϕ, prograde)
     end
 end
 
-angmom(m, r; contra_rotating = false, prograde = true) =
-    let rθ = @SVector([r, π / 2])
-        Ωϕ = Ω(m, rθ, contra_rotating)
-        __angmom(metric_components(m, rθ), Ωϕ, prograde)
-    end
+function angmom(m, rθ; contra_rotating = false, prograde = true)
+    Ωϕ = Ω(m, rθ; contra_rotating = contra_rotating)
+    __angmom(metric_components(m, rθ), Ωϕ, prograde)
+end
+angmom(m::AbstractAutoDiffStaticAxisSymmetricParams, r::Number; kwargs...) =
+    angmom(m, @SVector([r, π / 2]); kwargs...)
 
 function g_ginv_energy_angmom(
-    m::AbstractAutoDiffStaticAxisSymmetricParams{T},
-    r;
+    m::AbstractAutoDiffStaticAxisSymmetricParams,
+    rθ;
     contra_rotating = false,
     prograde = true,
-) where {T}
-    let rθ = @SVector([r, π / 2])
+)
+    g = metric_components(m, rθ)
+    ginv = inverse_metric_components(g)
 
-        g = metric_components(m, rθ)
-        ginv = inverse_metric_components(g)
+    Ωϕ = Ω(m, rθ; contra_rotating = contra_rotating)
+    E = __energy(g, Ωϕ)
+    L = __angmom(g, Ωϕ, prograde)
 
-        Ωϕ = Ω(m, rθ, contra_rotating)
-        E = __energy(g, Ωϕ)
-        L = __angmom(g, Ωϕ, prograde)
-
-        (g, ginv, E, L)
-    end
+    (g, ginv, E, L)
 end
 
 function __vϕ(ginv, E, L)
     -E * ginv[5] + L * ginv[4]
 end
 
-function vϕ(m::AbstractAutoDiffStaticAxisSymmetricParams{T}, r; kwargs...) where {T}
-    _, ginv, E, L = g_ginv_energy_angmom(m, r; kwargs...)
+function vϕ(m::AbstractAutoDiffStaticAxisSymmetricParams, rθ; kwargs...)
+    _, ginv, E, L = g_ginv_energy_angmom(m, rθ; kwargs...)
     __vϕ(ginv, E, L)
 end
+vϕ(m::AbstractAutoDiffStaticAxisSymmetricParams, r::Number; kwargs...) =
+    vϕ(m, @SVector([r, π / 2]); kwargs...)
 
 # this component doesn't actually seem to correctly constrain the geodesic
 # to being light- / null-like, or timelike. maybe revist? else call constrain before returning
@@ -77,30 +82,34 @@ function __vt(ginv, E, L)
     -E * ginv[1] + L * ginv[5]
 end
 
-function vt(m::AbstractAutoDiffStaticAxisSymmetricParams{T}, r; kwargs...) where {T}
-    _, ginv, E, L = g_ginv_energy_angmom(m, r; kwargs...)
+function vt(m::AbstractAutoDiffStaticAxisSymmetricParams, rθ; kwargs...)
+    _, ginv, E, L = g_ginv_energy_angmom(m, rθ; kwargs...)
     __vt(ginv, E, L)
 end
+vt(m::AbstractAutoDiffStaticAxisSymmetricParams, r::Number; kwargs...) =
+    vt(m, @SVector([r, π / 2]); kwargs...)
 
 function fourvelocity(
-    m::AbstractAutoDiffStaticAxisSymmetricParams{T},
-    r;
+    m::AbstractAutoDiffStaticAxisSymmetricParams,
+    rθ;
     kwargs...,
-) where {T}
-    _, ginv, E, L = g_ginv_energy_angmom(m, r; kwargs...)
+)
+    _, ginv, E, L = g_ginv_energy_angmom(m, rθ; kwargs...)
 
     vt = __vt(ginv, E, L)
     vϕ = __vϕ(ginv, E, L)
 
     @SVector [vt, 0.0, 0.0, vϕ]
 end
+fourvelocity(m::AbstractAutoDiffStaticAxisSymmetricParams, r::Number; kwargs...) =
+    fourvelocity(m, @SVector([r, π / 2]); kwargs...)
 
 function plunging_fourvelocity(
-    m::AbstractAutoDiffStaticAxisSymmetricParams{T},
-    r;
+    m::AbstractAutoDiffStaticAxisSymmetricParams,
+    rθ;
     kwargs...,
-) where {T}
-    g, ginv, E, L = g_ginv_energy_angmom(m, r; kwargs...)
+)
+    g, ginv, E, L = g_ginv_energy_angmom(m, rθ; kwargs...)
     vt = __vt(ginv, E, L)
     vϕ = __vϕ(ginv, E, L)
 
@@ -109,6 +118,8 @@ function plunging_fourvelocity(
 
     @SVector[vt, -sqrt(abs(nom / denom)), 0.0, vϕ]
 end
+plunging_fourvelocity(m::AbstractAutoDiffStaticAxisSymmetricParams, r::Number; kwargs...) =
+    plunging_fourvelocity(m, @SVector([r, π / 2]); kwargs...)
 
 end # module
 

--- a/src/orbits/circular-orbits.jl
+++ b/src/orbits/circular-orbits.jl
@@ -6,11 +6,7 @@ import ..Gradus:
     metric_jacobian,
     inverse_metric_components
 
-function Ω(
-    m::AbstractAutoDiffStaticAxisSymmetricParams,
-    rθ;
-    contra_rotating = false,
-)
+function Ω(m::AbstractAutoDiffStaticAxisSymmetricParams, rθ; contra_rotating = false)
     _, jacs = metric_jacobian(m, rθ)
     ∂rg = jacs[:, 1]
 
@@ -89,11 +85,7 @@ end
 vt(m::AbstractAutoDiffStaticAxisSymmetricParams, r::Number; kwargs...) =
     vt(m, @SVector([r, π / 2]); kwargs...)
 
-function fourvelocity(
-    m::AbstractAutoDiffStaticAxisSymmetricParams,
-    rθ;
-    kwargs...,
-)
+function fourvelocity(m::AbstractAutoDiffStaticAxisSymmetricParams, rθ; kwargs...)
     _, ginv, E, L = g_ginv_energy_angmom(m, rθ; kwargs...)
 
     vt = __vt(ginv, E, L)
@@ -104,11 +96,7 @@ end
 fourvelocity(m::AbstractAutoDiffStaticAxisSymmetricParams, r::Number; kwargs...) =
     fourvelocity(m, @SVector([r, π / 2]); kwargs...)
 
-function plunging_fourvelocity(
-    m::AbstractAutoDiffStaticAxisSymmetricParams,
-    rθ;
-    kwargs...,
-)
+function plunging_fourvelocity(m::AbstractAutoDiffStaticAxisSymmetricParams, rθ; kwargs...)
     g, ginv, E, L = g_ginv_energy_angmom(m, rθ; kwargs...)
     vt = __vt(ginv, E, L)
     vϕ = __vϕ(ginv, E, L)

--- a/src/orbits/orbit-interpolations.jl
+++ b/src/orbits/orbit-interpolations.jl
@@ -14,13 +14,13 @@ struct PlungingInterpolation{M,_interp_type}
         vr = sol[6, :][I]
         vϕ = sol[8, :][I]
 
-        rinterp = LinearInterpolation(r, vt)
+        rinterp = LinearInterpolation(r, vt; extrapolation_bc = Line())
 
         new{M,typeof(rinterp)}(
             m,
             rinterp,
-            LinearInterpolation(r, vr),
-            LinearInterpolation(r, vϕ),
+            LinearInterpolation(r, vr; extrapolation_bc = Line()),
+            LinearInterpolation(r, vϕ; extrapolation_bc = Line()),
         )
     end
 end

--- a/src/redshift.jl
+++ b/src/redshift.jl
@@ -162,7 +162,7 @@ end
     u_disc = @SVector [1 / disc_norm, 0, 0, Ωₑ(m.M, u[2], m.a) / disc_norm]
 
     # use Tullio to do the einsum
-    @tullio g := metric_matrix[i, j] * u_disc[i] * (-v[j])
+    @tullio g := -metric_matrix[i, j] * u_disc[i] * v[j]
     1 / g
 end
 

--- a/src/tracing/method-implementations/auto-diff.jl
+++ b/src/tracing/method-implementations/auto-diff.jl
@@ -266,12 +266,12 @@ function metric_jacobian(m::AbstractAutoDiffStaticAxisSymmetricParams, rθ)
 end
 
 @inbounds function geodesic_eq(
-    m::AbstractAutoDiffStaticAxisSymmetricParams{T},
-    u,
-    v,
+    m::AbstractAutoDiffStaticAxisSymmetricParams,
+    u::AbstractArray{T},
+    v::AbstractArray{T},
 ) where {T}
     # get the only position components we need for this metric type
-    rθ = SVector{2,Float64}(u[2], u[3])
+    rθ = SVector{2,T}(u[2], u[3])
     # calculate all non-zero components, and use AD to get derivatives
     g_comps, jacs = metric_jacobian(m, rθ)
     # calculate all non-zero inverse matric components

--- a/src/tracing/tracing.jl
+++ b/src/tracing/tracing.jl
@@ -4,7 +4,7 @@
         position,
         velocity,
         time_domain::Tuple{T,T};
-        solver = TsitPap8(),
+        solver = Tsit5(),
         μ = 0.0,
         closest_approach = 1.01,
         effective_infinity = 1200.0,
@@ -30,7 +30,7 @@ function tracegeodesics(
     position,
     velocity,
     time_domain::Tuple{T,T};
-    solver = TsitPap8(),
+    solver = Tsit5(),
     μ = 0.0,
     closest_approach = 1.01,
     effective_infinity = 1200.0,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
-using Gradus, StaticArrays
 using Test
+using Gradus
+using StaticArrays
 using Aqua
+using Tullio
 
 include("smoke-tests/rendergeodesics.jl")
 include("smoke-tests/tracegeodesics.jl")
@@ -9,6 +11,8 @@ include("smoke-tests/circular-orbits.jl")
 include("smoke-tests/disc-profiles.jl")
 include("smoke-tests/special-radii.jl")
 include("smoke-tests/cunningham-transfer-functions.jl")
+
+include("unit/gradusbase.geometry.jl")
 
 # little bit of aqua
 Aqua.test_undefined_exports(Gradus)

--- a/test/unit/gradusbase.geometry.jl
+++ b/test/unit/gradusbase.geometry.jl
@@ -33,10 +33,10 @@
     @testset "lnrf" begin
         for m in all_metrics, r in radii, θ in angles
             u = @SVector([0.0, r, θ, 0.0])
-    
+
             # function that we are testing
             M = Gradus.GradusBase.lnrframe(m, u)
-    
+
             m_mat = Gradus.metric(m, u)
             @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
             # ensure it gives minkowski
@@ -52,31 +52,31 @@
             A = Gradus.__BoyerLindquistFO.A(m.M, u[2], m.a, u[3])
             Σ = Gradus.__BoyerLindquistFO.Σ(u[2], m.a, u[3])
             Δ = Gradus.__BoyerLindquistFO.Δ(m.M, u[2], m.a)
-            ω = 2* m.M *m.a * u[2] / A
-        
+            ω = 2 * m.M * m.a * u[2] / A
+
             et = √(A / (Σ * Δ)) * @SVector [1.0, 0.0, 0.0, ω]
             er = √(Δ / Σ) * @SVector [0.0, 1.0, 0.0, 0.0]
             eθ = √(1 / Σ) * @SVector [0.0, 0.0, 1.0, 0.0]
-            eϕ = √(Σ / A) * (1/sin(u[3])) * @SVector [0.0, 0.0, 0.0, 1.0]
+            eϕ = √(Σ / A) * (1 / sin(u[3])) * @SVector [0.0, 0.0, 0.0, 1.0]
 
             vecs = (et, er, eθ, eϕ)
             reduce(hcat, vecs)
         end
-        
+
         function numerical_lnrframe(m, u)
             vecs = Gradus.GradusBase.lnrframe(m, u)
             reduce(hcat, vecs)
         end
 
-        for M in 0.2:0.8:2.0, a in -M:0.5:M
+        for M = 0.2:0.8:2.0, a = -M:0.5:M
             m = BoyerLindquistAD(M, a)
             r = inner_radius(m) + 4.2
             for θ in angles
-                u = @SVector [0.0, r, θ, 0.0] 
+                u = @SVector [0.0, r, θ, 0.0]
                 expected = kerr_lnrframe(m, u)
                 calculated = numerical_lnrframe(m, u)
 
-                @test isapprox(calculated, expected, atol=1e-13)
+                @test isapprox(calculated, expected, atol = 1e-13)
             end
         end
     end
@@ -86,8 +86,8 @@
             A = Gradus.__BoyerLindquistFO.A(m.M, u[2], m.a, u[3])
             Σ = Gradus.__BoyerLindquistFO.Σ(u[2], m.a, u[3])
             Δ = Gradus.__BoyerLindquistFO.Δ(m.M, u[2], m.a)
-            ω = 2* m.M *m.a * u[2] / A
-        
+            ω = 2 * m.M * m.a * u[2] / A
+
             et = √(Σ * Δ / A) * @SVector [1.0, 0.0, 0.0, 0.0]
             er = √(Σ / Δ) * @SVector [0.0, 1.0, 0.0, 0.0]
             eθ = √Σ * @SVector [0.0, 0.0, 1.0, 0.0]
@@ -96,21 +96,21 @@
             vecs = (et, er, eθ, eϕ)
             reduce(hcat, vecs)
         end
-        
+
         function numerical_lnrbasis(m, u)
             vecs = Gradus.GradusBase.lnrbasis(m, u)
             reduce(hcat, vecs)
         end
 
-        for M in 0.2:0.8:2.0, a in -M:0.5:M
+        for M = 0.2:0.8:2.0, a = -M:0.5:M
             m = BoyerLindquistAD(M, a)
             r = inner_radius(m) + 0.3
             for θ in angles
-                u = @SVector [0.0, r, θ, 0.1] 
+                u = @SVector [0.0, r, θ, 0.1]
                 expected = kerr_lnrbasis(m, u)
                 calculated = numerical_lnrbasis(m, u)
 
-                @test isapprox(calculated, expected, atol=1e-10) 
+                @test isapprox(calculated, expected, atol = 1e-10)
             end
         end
     end

--- a/test/unit/gradusbase.geometry.jl
+++ b/test/unit/gradusbase.geometry.jl
@@ -49,15 +49,16 @@
         # theory of the Kerr metric
 
         function kerr_lnrframe(m, u)
-            rθ = @SVector [u[2], u[3]]
-            gcomp = metric_components(m, rθ)
-            ginv = inverse_metric_components(gcomp)
-            w = -gcomp[5] / gcomp[4]
+            A = Gradus.__BoyerLindquistFO.A(m.M, u[2], m.a, u[3])
+            Σ = Gradus.__BoyerLindquistFO.Σ(u[2], m.a, u[3])
+            Δ = Gradus.__BoyerLindquistFO.Δ(m.M, u[2], m.a)
+            ω = 2* m.M *m.a * u[2] / A
         
-            et = √(-ginv[1]) * @SVector [1.0, 0.0, 0.0, w]
-            er = √ginv[2] * @SVector [0.0, 1.0, 0.0, 0.0]
-            eθ = √ginv[3] * @SVector [0.0, 0.0, 1.0, 0.0]
-            eϕ = √(ginv[4] - w^2 * ginv[1]) * @SVector [0.0, 0.0, 0.0, 1.0]
+            et = √(A / (Σ * Δ)) * @SVector [1.0, 0.0, 0.0, ω]
+            er = √(Δ / Σ) * @SVector [0.0, 1.0, 0.0, 0.0]
+            eθ = √(1 / Σ) * @SVector [0.0, 0.0, 1.0, 0.0]
+            # unsure why this is negative
+            eϕ = √(Σ / A) * (1/sin(u[3])) * @SVector [0.0, 0.0, 0.0, 1.0]
             vecs = (et, er, eθ, eϕ)
         
             reduce(hcat, vecs)

--- a/test/unit/gradusbase.geometry.jl
+++ b/test/unit/gradusbase.geometry.jl
@@ -1,4 +1,3 @@
-
 @testset "tetradframe" begin
     all_metrics = (
         # can't do first order yet since no four velocity
@@ -8,7 +7,7 @@
         BoyerLindquistAD(1.0, -0.998),
         JohannsenAD(M = 1.0, a = 0.998, α13 = 1.0),
         JohannsenAD(M = 1.0, a = 0.998, α22 = 1.0),
-        DilatonAxionAD(M = 1.0, a = 0.998, β = 0.2, b = 1.0),
+        # DilatonAxionAD(M = 1.0, a = 0.998, β = 0.2, b = 1.0),
     )
     radii = 5.0:0.8:10.0
     angles = 0.1:0.5:2π
@@ -29,5 +28,20 @@
         @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
         # ensure it gives minkowski
         @test isapprox(res, minkowski, atol = 1e-13)
+    end
+
+
+    @testset "lnrf" begin
+        for m in all_metrics, r in radii, θ in angles
+            u = @SVector([0.0, r, θ, 0.0])
+    
+            # function that we are testing
+            M = GradusBase.lnrframe(m, u)
+    
+            m_mat = Gradus.metric(m, u)
+            @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
+            # ensure it gives minkowski
+            @test isapprox(res, minkowski, atol = 1e-13)
+        end
     end
 end

--- a/test/unit/gradusbase.geometry.jl
+++ b/test/unit/gradusbase.geometry.jl
@@ -13,10 +13,10 @@
     radii = 5.0:0.8:10.0
     angles = 0.1:0.5:2π
     minkowski = @SMatrix [
-       -1.0 0.0 0.0 0.0 ;
-        0.0 1.0 0.0 0.0 ;
-        0.0 0.0 1.0 0.0 ;
-        0.0 0.0 0.0 1.0 
+        -1.0 0.0 0.0 0.0
+        0.0 1.0 0.0 0.0
+        0.0 0.0 1.0 0.0
+        0.0 0.0 0.0 1.0
     ]
     for m in all_metrics, r in radii, θ in angles
         u = @SVector([0.0, r, θ, 0.0])
@@ -28,6 +28,6 @@
         m_mat = Gradus.metric(m, u)
         @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
         # ensure it gives minkowski
-        @test isapprox(res, minkowski, atol=1e-13)
+        @test isapprox(res, minkowski, atol = 1e-13)
     end
 end

--- a/test/unit/gradusbase.geometry.jl
+++ b/test/unit/gradusbase.geometry.jl
@@ -22,7 +22,7 @@
         v = Gradus.constrain_all(m, u, CircularOrbits.fourvelocity(m, r), 1.0)
 
         # function that we are testing
-        M = GradusBase.tetradframe(m, u, v)
+        M = Gradus.GradusBase.tetradframe(m, u, v)
 
         m_mat = Gradus.metric(m, u)
         @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
@@ -35,7 +35,7 @@
             u = @SVector([0.0, r, θ, 0.0])
     
             # function that we are testing
-            M = GradusBase.lnrframe(m, u)
+            M = Gradus.GradusBase.lnrframe(m, u)
     
             m_mat = Gradus.metric(m, u)
             @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
@@ -57,10 +57,9 @@
             et = √(A / (Σ * Δ)) * @SVector [1.0, 0.0, 0.0, ω]
             er = √(Δ / Σ) * @SVector [0.0, 1.0, 0.0, 0.0]
             eθ = √(1 / Σ) * @SVector [0.0, 0.0, 1.0, 0.0]
-            # unsure why this is negative
             eϕ = √(Σ / A) * (1/sin(u[3])) * @SVector [0.0, 0.0, 0.0, 1.0]
+
             vecs = (et, er, eθ, eϕ)
-        
             reduce(hcat, vecs)
         end
         
@@ -93,8 +92,8 @@
             er = √(Σ / Δ) * @SVector [0.0, 1.0, 0.0, 0.0]
             eθ = √Σ * @SVector [0.0, 0.0, 1.0, 0.0]
             eϕ = √(A / Σ) * sin(u[3]) * @SVector [-ω, 0.0, 0.0, 1.0]
+
             vecs = (et, er, eθ, eϕ)
-        
             reduce(hcat, vecs)
         end
         


### PR DESCRIPTION
Implemented a model for calculating source to disc (reflected) flux for stationary lamp-posts that is metric generic, based off of the tetrad formalism from the previous commits.

It's worth noting that there are analytic LNR frames and bases that can be written in terms of the metric and inverse metric components analytically for stationary, axis-symmetric spacetimes, which will probably outperform the Gram-Schmidt algorithm I've written. These should seriously be added should this line become performance critical! I've left them out for now because I quite like the Gram-Schmidt process, and invested time getting it to work 👍 

Once the isotropic angle mapping for other metrics is done (PR soon hopefully), then the 2d-transfer function calculations should be ready to work with any of our metrics!

