### PR TITLE
Metric generic angle mapping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.12"
+version = "0.1.13"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/GradusBase/geometry.jl
+++ b/src/GradusBase/geometry.jl
@@ -4,6 +4,7 @@ end
 
 dotproduct(g::AbstractMatrix, v1, v2) = @tullio r := g[i, j] * v1[i] * v2[j]
 propernorm(g::AbstractMatrix, v) = dotproduct(g, v, v)
+propernorm(m::AbstractMetricParams, u, v) = propernorm(metric(m, u), v)
 
 """
     mproject(g, v, u)
@@ -49,7 +50,7 @@ end
 tetradframe(m::AbstractMetricParams, u, v) = tetradframe(metric(m, u), v)
 
 # TODO: this presupposes static and axis symmetric
-# tetrad with indices down: frame
+# tetrad with latin indices down: frame
 function lnrframe(g::AbstractMatrix)
     ω = -g[1, 4] / g[4, 4]
     v = @SVector [1.0, 0.0, 0.0, ω]
@@ -57,7 +58,7 @@ function lnrframe(g::AbstractMatrix)
 end
 lnrframe(m::AbstractMetricParams, u) = lnrframe(metric(m, u))
 
-# tetrad with indices up: basis
+# tetrad with latin indices up: basis
 function lnrbasis(g::AbstractMatrix)
     ω = -g[1, 4] / g[4, 4]
     v = @SVector [-ω, 0.0, 0.0, 1.0]

--- a/src/corona-to-disc/corona-models.jl
+++ b/src/corona-to-disc/corona-models.jl
@@ -1,5 +1,62 @@
-sample_position(m::AbstractMetricParams{T}, model::AbstractCoronaModel{T}, N) where {T} =
+# todo: this should take into account position
+function source_velocity(::AbstractMetricParams, model::AbstractCoronaModel)
     error("Not implemented for $(typeof(model)).")
+end
+
+function sample_position(
+    ::AbstractMetricParams{T},
+    model::AbstractCoronaModel{T},
+    N,
+) where {T}
+    error("Not implemented for $(typeof(model)).")
+end
+
+"""
+    sample_velocity(
+        m::AbstractMetricParams, 
+        model::AbstractCoronaModel, 
+        sampler::AbstractDirectionSampler, 
+        us, 
+        N
+    )
+
+Sample `N` initial (un-normalised) velocities in the local coordinates of the `model`, according to
+the [`AbstractDirectionSampler`](@ref) algorithm and domain, given initial 4-vector positions `us`.
+
+This function is metric generic and is implemented in the following way:
+- Sample angles ``\\alpha`` and ``\\beta`` in the local sky.
+- Map these angles to a spherical polar vector (interally first to Cartesian and then using a Jacobian
+transformation to spherical polar).
+- Calculate the local tetrad given the source velocity at `u = us[i]`.
+- Use this tetrad to map the local vector to the global coordinates.
+"""
+function sample_velocity(
+    m::AbstractMetricParams{T},
+    model::AbstractCoronaModel{T},
+    sampler::AbstractDirectionSampler,
+    us,
+    N,
+) where {T}
+    u_source = source_velocity(m, model)
+    @inbounds map(1:N) do index
+        # todo: sampler should have proper iterator interface
+        i = geti(sampler, index, N)
+        θ, ϕ = sample_angles(sampler, i, N)
+
+        u = us[index]
+        # multiply by -1 for consitency with LowerHemisphere()
+        hat = -1 * _cart_local_direction(θ, ϕ)
+        J = _cart_to_spher_jacobian(u[3], u[4])
+        (r, t, p) = J * hat
+
+        v = @SVector [T(0.0), r, t, p]
+
+        basis = tetradframe(m, u, u_source)
+        B = reduce(hcat, basis)
+        B * v
+    end
+end
+
 
 @with_kw struct LampPostModel{T} <: AbstractCoronaModel{T}
     @deftype T
@@ -11,26 +68,6 @@ end
 function sample_position(::AbstractMetricParams{T}, model::LampPostModel{T}, N) where {T}
     u = @SVector [T(0.0), model.h, model.θ, model.ϕ]
     fill(u, N)
-end
-
-function sample_velocity(
-    m::AbstractMetricParams{T},
-    ::AbstractCoronaModel{T},
-    sampler::AbstractDirectionSampler,
-    us,
-    N,
-) where {T}
-    map(1:N) do index
-        # todo: sampler should have proper iterator interface
-        i = geti(sampler, index, N)
-        θ, ϕ = sample_angles(sampler, i, N)
-        r, t, p = vector_to_local_sky(m, us[index], θ, ϕ)
-        @SVector [T(0.0), r, t, p]
-    end
-end
-
-function source_velocity(m::AbstractMetricParams, model::AbstractCoronaModel)
-    error("Not implemented for $(typeof(model)).")
 end
 
 function source_velocity(m::AbstractMetricParams, model::LampPostModel)

--- a/src/corona-to-disc/flux-calculations.jl
+++ b/src/corona-to-disc/flux-calculations.jl
@@ -6,7 +6,7 @@ Calculate Lorentz factor in LNRF of `u`.
 function lorentz_factor(g::AbstractMatrix, isco_r, u, v)
     frame = Gradus.GradusBase.lnrbasis(g)
     B = reduce(hcat, frame)
-    denom = B[:, 1] ⋅ v 
+    denom = B[:, 1] ⋅ v
 
     𝒱ϕ = (B[:, 4] ⋅ v) / denom
 
@@ -30,7 +30,7 @@ end
 
 function flux_source_to_disc(
     m::AbstractMetricParams,
-    model::LampPostModel,
+    model::AbstractCoronaModel,
     vdp::VoronoiDiscProfile;
     α = 1.0,
 )
@@ -73,6 +73,7 @@ function flux_source_to_disc(
         # total reflected flux 
         g_sd^(1 + α) * E_d^(-α) * dA * f_sd / γ
     end
+
     map(flux, enumerate(vdp.geodesic_points))
 end
 

--- a/src/corona-to-disc/sky-geometry.jl
+++ b/src/corona-to-disc/sky-geometry.jl
@@ -34,9 +34,9 @@ end
 
 
 sample_angles(sm::AbstractDirectionSampler{D,G}, i, N) where {D,G} =
-    (sample_elevation(sm, i / N), sample_azimuth(sm, i))
+    (sample_elevation(sm, i / N), mod2pi(sample_azimuth(sm, i)))
 @inline sample_angles(sm::WeierstrassSampler{D}, i, N) where {D} =
-    (sample_elevation(sm, i), sample_azimuth(sm, i))
+    (sample_elevation(sm, i), mod2pi(sample_azimuth(sm, i)))
 
 
 sample_elevation(sm::AbstractDirectionSampler{D,G}, i) where {D,G} =
@@ -44,7 +44,7 @@ sample_elevation(sm::AbstractDirectionSampler{D,G}, i) where {D,G} =
 @inline sample_elevation(::EvenSampler{LowerHemisphere}, i) = acos(1 - i)
 @inline sample_elevation(::EvenSampler{BothHemispheres}, i) = acos(1 - 2i)
 @inline sample_elevation(sm::WeierstrassSampler{LowerHemisphere}, i) =
-    π - 2atan(√(sm.resolution / i))
+    2atan(√(sm.resolution / i))
 @inline function sample_elevation(sm::WeierstrassSampler{BothHemispheres}, i)
     ϕ = 2atan(√(sm.resolution / i))
     if iseven(i)
@@ -52,6 +52,18 @@ sample_elevation(sm::AbstractDirectionSampler{D,G}, i) where {D,G} =
     else
         π - ϕ
     end
+end
+
+function _cart_to_spher_jacobian(θ, ϕ)
+    @SMatrix [
+        sin(θ)*cos(ϕ) sin(θ)*sin(ϕ) cos(θ)
+        cos(θ)*cos(ϕ) cos(θ)*sin(ϕ) -sin(θ)
+        -sin(ϕ) cos(ϕ) 0
+    ]
+end
+
+function _cart_local_direction(θ, ϕ)
+    @SVector [sin(θ) * cos(ϕ), sin(θ) * sin(ϕ), cos(θ)]
 end
 
 export LowerHemisphere,

--- a/test/smoke-tests/disc-profiles.jl
+++ b/test/smoke-tests/disc-profiles.jl
@@ -31,17 +31,17 @@
         areas2 = getareas(vdp2)
 
         # values computed under visual inspection
-        # last computed 15/11/2022: continuous callback for disc intersection
+        # last computed 03/10/22: updated sampling method
         expected_areas = [
-            89.79326183804586,
-            117.69063502043767,
-            141.71137385746914,
-            233.49741646976452,
-            683.6491180876137,
-            736.059111143716,
-            675.7846796957201,
-            490.44994928380703,
-            372.2875995001252,
+            75.64302307389167,
+            114.78829414215679,
+            166.581361553731,
+            263.3161757085493,
+            700.3526293678786,
+            739.2923798563061,
+            645.4220326474972,
+            477.8144794927597,
+            359.1850275798407,
         ]
         @test all(isapprox.(areas1, expected_areas, atol = 1e-3))
         @test all(isapprox.(areas2, expected_areas, atol = 1e-3))


### PR DESCRIPTION
I _think_ this is now an okay way to map local sky angles to coordinate 4-velocity vectors for all supported metrics (bar #52). The reflected flux calculated in the reverberation lags is a little higher than previously, but given that these are abstract units we can rescale as (/if) needed

![emissivity-test-1 664818837951219e9](https://user-images.githubusercontent.com/11492844/193691303-8ba62152-1bdf-495e-ac10-16d09332aeef.png)

Here standard is the old sampler, which was lifted from a Younsi et al. (2016) paper (I think) and wasn't every really checked.

The photon paths disagree a little between the two methods:

![lamp-post-kerr-588629168354583](https://user-images.githubusercontent.com/11492844/193691589-105da61f-a99c-4e61-85b6-77c76f52cd0c.png)

But agree completely for the flat case (M = eps).

The full reverberation transfer functions calculated differ insignificantly.

Hopefully the doc-string for the method is detailed enough to illustrate how this was done. Generated documentation updates to follow!