### PR TITLE
Status codes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.19"
+version = "0.1.20"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -9,6 +9,7 @@ Buckets = "3235f445-51d8-4100-901d-5b23398ac3ab"
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
@@ -26,6 +27,3 @@ Surrogates = "6fc51010-71bc-11e9-0e15-a3fcc6593c49"
 ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 VoronoiCells = "e3e34ffb-84e9-5012-9490-92c94d0c60a4"
-
-[compat]
-SciMLBase = "=1.62.0"

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -56,7 +56,10 @@ import .GradusBase:
     lnrbasis,
     lnrframe,
     lowerindices,
-    raiseindices
+    raiseindices,
+    StatusCodes,
+    AbstractIntegrationParameters,
+    IntegrationParameters
 
 export AbstractMetricParams,
     getgeodesicpoint,
@@ -74,7 +77,10 @@ export AbstractMetricParams,
     lnrbasis,
     lnrframe,
     lowerindices,
-    raiseindices
+    raiseindices,
+    StatusCodes,
+    AbstractIntegrationParameters,
+    IntegrationParameters
 
 """
     abstract type AbstractPointFunction

--- a/src/GradusBase/GradusBase.jl
+++ b/src/GradusBase/GradusBase.jl
@@ -7,11 +7,18 @@ using Parameters: @with_kw
 using StaticArrays: SVector, MMatrix, SMatrix, @SVector
 using Tullio: @tullio
 using LinearAlgebra: norm, inv
+using EnumX
 
 # for doc bindings
 import ..Gradus
 
 using DocStringExtensions
+
+@enumx StatusCodes begin
+    OutOfDomain
+    IntersectedWithGeometry
+    NoStatus
+end
 
 include("metric-params.jl")
 include("geodesic-solutions.jl")
@@ -36,6 +43,8 @@ tetradframe,
 lnrbasis,
 lnrframe,
 lowerindices,
-raiseindices
+raiseindices,
+StatusCodes,
+IntegrationParameters
 
 end # module

--- a/src/GradusBase/geodesic-solutions.jl
+++ b/src/GradusBase/geodesic-solutions.jl
@@ -1,3 +1,9 @@
+abstract type AbstractIntegrationParameters end
+
+mutable struct IntegrationParameters <: AbstractIntegrationParameters
+    status::StatusCodes.T
+end
+
 """
     abstract type AbstractGeodesicPoint
 
@@ -21,7 +27,7 @@ $(FIELDS)
 """
 @with_kw struct GeodesicPoint{T,V<:AbstractVector} <: AbstractGeodesicPoint{T}
     "Return code of the integrator for this geodesic."
-    retcode::Symbol
+    status::StatusCodes.T
     "Start affine time"
     t1::T
     "End affine time"
@@ -62,14 +68,14 @@ function getgeodesicpoint(
         v_end = SVector{4,T}(us[end][5:8])
         t_end = ts[end]
 
-        GeodesicPoint(sol.retcode, t_start, t_end, u_start, u_end, v_start, v_end)
+        GeodesicPoint(sol.prob.p.status, t_start, t_end, u_start, u_end, v_start, v_end)
     end
 end
 
 """
     $(TYPEDSIGNATURES)
 
-Unpacks each point in the solution, similar to [`getgeodesicpoint`](@ref) but returns an 
+Unpacks each point in the solution, similar to [`getgeodesicpoint`](@ref) but returns an
 array of [`GeodesicPoint`](@ref).
 """
 function getgeodesicpoints(
@@ -85,7 +91,7 @@ function getgeodesicpoints(
             ui = SVector{4,T}(us[i][1:4])
             vi = SVector{4,T}(us[i][5:8])
             ti = ts[i]
-            GeodesicPoint(sol.retcode, t_start, ti, u_start, ui, v_start, vi)
+            GeodesicPoint(sol.prob.p.status, t_start, ti, u_start, ui, v_start, vi)
         end
     end
 end

--- a/src/accretion-geometry/bootstrap.jl
+++ b/src/accretion-geometry/bootstrap.jl
@@ -66,6 +66,6 @@ function build_collision_callback(g::AbstractAccretionGeometry{T}; gtol) where {
     DiscreteCallback(
         (u, λ, integrator) ->
             intersects_geometry(g, line_element(u, integrator), integrator),
-        i -> terminate!(i, :Intersected),
+        terminate_with_status!(StatusCodes.IntersectedWithGeometry),
     )
 end

--- a/src/accretion-geometry/discs.jl
+++ b/src/accretion-geometry/discs.jl
@@ -46,7 +46,7 @@ function build_collision_callback(
 ) where {T}
     ContinuousCallback(
         (u, λ, integrator) -> distance_to_disc(g, u; gtol = gtol),
-        i -> terminate!(i, :Intersected);
+        terminate_with_status!(StatusCodes.IntersectedWithGeometry),
         interp_points = interp_points,
         save_positions = (true, false),
     )

--- a/src/accretion-geometry/meshes.jl
+++ b/src/accretion-geometry/meshes.jl
@@ -71,7 +71,7 @@ function build_collision_callback(g::MeshAccretionGeometry{T}; gtol) where {T}
     DiscreteCallback(
         (u, λ, integrator) ->
             intersects_geometry(g, cartesian_line_element(u, integrator), integrator),
-        i -> terminate!(i, :Intersected),
+        terminate_with_status!(StatusCodes.IntersectedWithGeometry),
     )
 end
 

--- a/src/const-point-functions.jl
+++ b/src/const-point-functions.jl
@@ -25,7 +25,7 @@ A [`FilterPointFunction`](@ref) that filters geodesics which intersected with th
 disc. Default: `NaN`.
 """
 const filter_intersected =
-    FilterPointFunction((m, gp, max_time; kwargs...) -> gp.retcode == :Intersected, NaN)
+    FilterPointFunction((m, gp, max_time; kwargs...) -> gp.status == StatusCodes.IntersectedWithGeometry, NaN)
 
 """
     affine_time(m::AbstractMetricParams, gp::AbstractGeodesicPoint, max_time)

--- a/src/corona-to-disc/disc-profiles.jl
+++ b/src/corona-to-disc/disc-profiles.jl
@@ -106,7 +106,7 @@ function VoronoiDiscProfile(
     d::AbstractAccretionDisc{T},
     simsols::SciMLBase.EnsembleSolution{T},
 ) where {T}
-    VoronoiDiscProfile(m, d, filter(i -> i.retcode == :Intersected, simsols.u))
+    VoronoiDiscProfile(m, d, filter(i -> i.prob.p.status == StatusCodes.IntersectedWithGeometry, simsols.u))
 end
 
 @noinline function findindex(vdp::VoronoiDiscProfile{D,V}, p) where {D,V}

--- a/src/cunningham-transfer.jl
+++ b/src/cunningham-transfer.jl
@@ -48,7 +48,7 @@ function find_offset_for_radius(
 )
     f = r -> begin
         gp = integrate_single_geodesic(m, u, d, r, θₒ; kwargs...)
-        r = if gp.retcode == :Intersected
+        r = if gp.status == StatusCodes.IntersectedWithGeometry
             gp.u2[2] * sin(gp.u2[3])
         else
             0.0

--- a/src/metrics/boyer-lindquist-fo.jl
+++ b/src/metrics/boyer-lindquist-fo.jl
@@ -360,11 +360,13 @@ calc_lq(m::BoyerLindquistFO{T}, pos, vel) where {T} =
     __BoyerLindquistFO.LQ(m.M, pos[2], m.a, pos[3], vel[3], vel[4])
 
 function Vr(m::BoyerLindquistFO{T}, u, p) where {T}
-    L, Q, _, _ = p
+    L = p.L
+    Q = p.Q
     __BoyerLindquistFO.Vr(m.E, L, m.M, Q, u[2], m.a)
 end
 function Vθ(m::BoyerLindquistFO{T}, u, p) where {T}
-    L, Q, _, _ = p
+    L = p.L
+    Q = p.Q
     __BoyerLindquistFO.Vθ(m.E, L, Q, m.a, u[3])
 end
 

--- a/src/tracing/callbacks.jl
+++ b/src/tracing/callbacks.jl
@@ -1,3 +1,10 @@
+function terminate_with_status!(status::StatusCodes.T)
+    integrator -> begin
+        integrator.p.status = status
+        terminate!(integrator)
+    end
+end
+
 @inline function ensure_chart_callback(
     m::AbstractMetricParams,
     closest_approach,
@@ -7,7 +14,7 @@
     # terminate integration if we come within some % of the black hole radius
     DiscreteCallback(
         (u, λ, integrator) -> u[2] ≤ min_r * closest_approach || u[2] > effective_infinity,
-        terminate!,
+        terminate_with_status!(StatusCodes.OutOfDomain),
     )
 end
 
@@ -32,10 +39,9 @@ function create_callback_set(
     end
 end
 
-
 # predefined callbacks
 function domain_upper_hemisphere(δ = 1e-3)
-    DiscreteCallback((u, t, integrator) -> u[2] * cos(u[3]) < δ, terminate!)
+    DiscreteCallback((u, t, integrator) -> u[2] * cos(u[3]) < δ, terminate_with_status!(StatusCodes.OutOfDomain))
 end
 
 export domain_upper_hemisphere

--- a/src/tracing/tracing.jl
+++ b/src/tracing/tracing.jl
@@ -78,7 +78,7 @@ function integrator_problem(
         end
     end
 
-    ODEProblem{false}(f, u_init, time_domain)
+    ODEProblem{false}(f, u_init, time_domain, IntegrationParameters(StatusCodes.NoStatus))
 end
 
 function integrator_problem(
@@ -98,7 +98,7 @@ function integrator_problem(
         end
     end
 
-    ODEProblem{true}(f!, u_init, time_domain)
+    ODEProblem{true}(f!, u_init, time_domain, IntegrationParameters(StatusCodes.NoStatus))
 end
 
 # single position and single velocity

--- a/test/smoke-tests/disc-profiles.jl
+++ b/test/smoke-tests/disc-profiles.jl
@@ -15,7 +15,7 @@
             sampler = EvenSampler(domain = LowerHemisphere()),
         )
 
-        intersected_simsols = filter(i -> i.retcode == :Intersected, simsols.u)
+        intersected_simsols = filter(i -> i.prob.p.status == StatusCodes.IntersectedWithGeometry, simsols.u)
         sd_endpoints = map(sol -> getgeodesicpoint(m, sol), intersected_simsols)
 
         # test ensemble solution constructor

--- a/test/smoke-tests/tracegeodesics.jl
+++ b/test/smoke-tests/tracegeodesics.jl
@@ -4,7 +4,7 @@
     # tests if a single geodesic can be integrated
     function test_single(m, u, v)
         sol = tracegeodesics(m, u, v, (0.0, 200.0))
-        @test sol.retcode == :Terminated
+        @test sol.retcode == Gradus.SciMLBase.ReturnCode.Terminated
         sol
     end
 
@@ -13,7 +13,7 @@
         us = [u, u, u]
         vs = [v, v, v]
         simsols = tracegeodesics(m, us, vs, (0.0, 200.0))
-        @test all(i -> simsols[i].retcode == :Terminated, 1:3)
+        @test all(i -> simsols[i].retcode == Gradus.SciMLBase.ReturnCode.Terminated, 1:3)
         simsols
     end
 


### PR DESCRIPTION
Due to recent changes in the SciML ecosystem, return codes are now enums instead of symbols, which means we can't piggy-back custom return codes anymore. Consequently, have to keep track of them using an (allocated :cry:) parameter structure, which is updated during calls to `terminate!`.

The performance hit of this is fairly small, about 1 allocation per geodesic, but given we already have GC issues, this might prove a little annoying.

A few things we can maybe do to cope with that
- custom solution structs before OrdinaryDiffEq.jl packages the structures together, and reduce allocations in parsing
- clever and targetted use of `GC.gc(false)`, as this was quite successful in the transfer functions

In theory there is no need for the integrator to allocate anything, given we are only interested in the initial and final 8-vectors (pos + vel), so perhaps we can go digging as see if there's anything we can do on that front as well.