### PR TITLE
Transfer functions: change root finding algorithm and scale initial position

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.20"
+version = "0.1.21"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/transfer-functions/cunningham-transfer-functions.jl
+++ b/src/transfer-functions/cunningham-transfer-functions.jl
@@ -165,6 +165,10 @@ function interpolated_transfer_branches(
     # IILF for calculating the interpolated branches
     𝔉 =
         rₑ -> begin
+            # want to scale the initial position with radius
+            # since redshift / jacobian values calculated at large impact parameters
+            # seem to be inaccurate? either that or the root finder is up to something
+            # but the problems seem to disappear by just keeping everything at low impact
             u_prob = SVector{4}(u[1], 1000 + 100rₑ, u[3], u[4])
             ctf = cunningham_transfer_function(
                 m,

--- a/src/transfer-functions/cunningham-transfer-functions.jl
+++ b/src/transfer-functions/cunningham-transfer-functions.jl
@@ -181,7 +181,7 @@ function interpolated_transfer_branches(
         end
 
     # calculate interpolated transfer functions for each emission radius
-    map(𝔉, radii)
+    ThreadsX.map(𝔉, radii)
 end
 
 export CunninghamTransferFunction,

--- a/src/transfer-functions/integration.jl
+++ b/src/transfer-functions/integration.jl
@@ -149,4 +149,4 @@ function integrate_drdg✶(
     flux
 end
 
-export integrate_drdg✶
+export integrate_drdg✶, g✶_to_g, g_to_g✶

--- a/test/smoke-tests/cunningham-transfer-functions.jl
+++ b/test/smoke-tests/cunningham-transfer-functions.jl
@@ -10,12 +10,7 @@
         [24.953515365137005, 22.91076063485734, 13.795031677382394, 11.086660268049126],
     )
         u = @SVector [0.0, 1000.0, deg2rad(angle), 0.0]
-        ctf = cunningham_transfer_function(
-            m,
-            u,
-            d,
-            4.0,
-        )
+        ctf = cunningham_transfer_function(m, u, d, 4.0)
         s = sum(ctf.f)
         @test isapprox(s, expected, atol = 1e-1, rtol = 0.0)
     end
@@ -27,12 +22,7 @@
         [23.491668065237214, 25.997534896876644, 26.73859117429336, 27.186165046726007],
     )
         u = @SVector [0.0, 1000.0, deg2rad(30), 0.0]
-        ctf = cunningham_transfer_function(
-            m,
-            u,
-            d,
-            r,
-        )
+        ctf = cunningham_transfer_function(m, u, d, r)
         s = sum(ctf.f)
         @test isapprox(s, expected, atol = 1e-2, rtol = 0.0)
     end

--- a/test/smoke-tests/cunningham-transfer-functions.jl
+++ b/test/smoke-tests/cunningham-transfer-functions.jl
@@ -6,24 +6,24 @@
     # test for different angles
     for (angle, expected) in zip(
         [3, 35, 74, 85],
-        # values last updated: 10/11/2022 - reimplemented algorithm
-        [24.953515365137005, 22.91076063485734, 13.795031677382394, 11.086660268049126],
+        # values last updated: 12/11/2022 - use means
+        [0.2495227986998514, 0.22911943722172406, 0.13792349421541406, 0.10360637290617522],
     )
         u = @SVector [0.0, 1000.0, deg2rad(angle), 0.0]
         ctf = cunningham_transfer_function(m, u, d, 4.0)
-        s = sum(ctf.f)
-        @test isapprox(s, expected, atol = 1e-1, rtol = 0.0)
+        s = sum(ctf.f) / length(ctf.f)
+        @test isapprox(s, expected, atol = 1e-3, rtol = 0.0)
     end
 
     # different radii
     for (r, expected) in zip(
         [4.0, 7.0, 10.0, 15.0],
-        # values last updated: 10/11/2022 - reimplemented algorithm
-        [23.491668065237214, 25.997534896876644, 26.73859117429336, 27.186165046726007],
+        # values last updated: 12/11/2022 - use means
+        [0.23492490558931373, 0.2599801835844643, 0.26738568957410025, 0.2718492609857089],
     )
         u = @SVector [0.0, 1000.0, deg2rad(30), 0.0]
         ctf = cunningham_transfer_function(m, u, d, r)
-        s = sum(ctf.f)
+        s = sum(ctf.f) / length(ctf.f)
         @test isapprox(s, expected, atol = 1e-2, rtol = 0.0)
     end
 end

--- a/test/smoke-tests/line-profiles.jl
+++ b/test/smoke-tests/line-profiles.jl
@@ -7,15 +7,7 @@
     @testset "cunningham" begin
         x = range(0.1, 1.2, 20)
         bins = range(0.0, 1.5, 200)
-        _, lp = lineprofile(
-            bins,
-            (r) -> r^(-3),
-            m,
-            u,
-            d;
-            N = 40,
-            numrₑ = 30
-        )
+        _, lp = lineprofile(bins, (r) -> r^(-3), m, u, d; N = 40, numrₑ = 30)
         @test isapprox(1.0, sum(lp), atol = 1e-4)
     end
 end


### PR DESCRIPTION
Transfer functions were being incorrectly calculated for large impact parameters -- presumably due to something in the way these are mapped in curve space. Everything seems to be fixed by just scaling the observer position with target emission radius, so that is done here.

Updated test values to reflect improved precision, and now use mean instead of sum as the validation metric, since number of points may change.

Also changed the root finder algorithm to Root's Order0, since this dramatically improves performance.