### PR TITLE
Chore!: simple hygiene and renames

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.26"
+version = "0.1.27"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.27"
+version = "0.2.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -36,8 +36,8 @@ import .GradusBase:
     AbstractMetricParams,
     metric_params,
     metric,
-    getgeodesicpoint,
-    getgeodesicpoints,
+    process_solution,
+    process_solution_full,
     GeodesicPoint,
     AbstractGeodesicPoint,
     vector_to_local_sky,
@@ -62,8 +62,8 @@ import .GradusBase:
     IntegrationParameters
 
 export AbstractMetricParams,
-    getgeodesicpoint,
-    getgeodesicpoints,
+    process_solution,
+    process_solution_full,
     GeodesicPoint,
     AbstractGeodesicPoint,
     AbstractMetricParams,

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -203,7 +203,7 @@ export AbstractPointFunction,
 precompile(
     tracegeodesics,
     (
-        BoyerLindquistAD{Float64},
+        KerrSpacetime{Float64},
         SVector{4,Float64},
         SVector{4,Float64},
         Tuple{Float64,Float64},
@@ -211,7 +211,7 @@ precompile(
 )
 precompile(
     rendergeodesics,
-    (BoyerLindquistAD{Float64}, SVector{4,Float64}, GeometricThinDisc{Float64}, Float64),
+    (KerrSpacetime{Float64}, SVector{4,Float64}, GeometricThinDisc{Float64}, Float64),
 )
 
 end # module

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -203,7 +203,7 @@ export AbstractPointFunction,
 precompile(
     tracegeodesics,
     (
-        KerrSpacetime{Float64},
+        KerrMetric{Float64},
         SVector{4,Float64},
         SVector{4,Float64},
         Tuple{Float64,Float64},
@@ -211,7 +211,7 @@ precompile(
 )
 precompile(
     rendergeodesics,
-    (KerrSpacetime{Float64}, SVector{4,Float64}, GeometricThinDisc{Float64}, Float64),
+    (KerrMetric{Float64}, SVector{4,Float64}, GeometricThinDisc{Float64}, Float64),
 )
 
 end # module

--- a/src/GradusBase/GradusBase.jl
+++ b/src/GradusBase/GradusBase.jl
@@ -26,7 +26,7 @@ include("geodesic-solutions.jl")
 include("geometry.jl")
 include("physical-quantities.jl")
 
-export AbstractMetricParams, metric_params, metric, getgeodesicpoint, getgeodesicpoints
+export AbstractMetricParams, metric_params, metric, process_solution, process_solution_full
 GeodesicPoint,
 AbstractGeodesicPoint,
 vector_to_local_sky,

--- a/src/GradusBase/geodesic-solutions.jl
+++ b/src/GradusBase/geodesic-solutions.jl
@@ -53,7 +53,7 @@ Used to get pack a `SciMLBase.AbstractODESolution` into a [`GeodesicPoint`](@ref
 information relevant to start and endpoint of the integration. To keep the full geodesic path, it is
 encouraged to use the `SciMLBase.AbstractODESolution` directly.
 """
-function getgeodesicpoint(
+function process_solution(
     _::AbstractMetricParams{T},
     sol::SciMLBase.AbstractODESolution{T,N,S},
 ) where {T,N,S}
@@ -75,10 +75,10 @@ end
 """
     $(TYPEDSIGNATURES)
 
-Unpacks each point in the solution, similar to [`getgeodesicpoint`](@ref) but returns an
+Unpacks each point in the solution, similar to [`process_solution`](@ref) but returns an
 array of [`GeodesicPoint`](@ref).
 """
-function getgeodesicpoints(
+function process_solution_full(
     _::AbstractMetricParams{T},
     sol::SciMLBase.AbstractODESolution{T,N,S},
 ) where {T,N,S}

--- a/src/GradusBase/geodesic-solutions.jl
+++ b/src/GradusBase/geodesic-solutions.jl
@@ -99,13 +99,11 @@ end
 # TODO: GeodesicPath structure for the full geodesic path
 # do we want to support this?
 
-function unpack_solution(sol::SciMLBase.AbstractODESolution{T,N,S}) where {T,N,S}
+function unpack_solution(sol::SciMLBase.AbstractODESolution)
     u = sol.u
     p = sol.prob.p
     t = sol.t
     (u, t, p)
 end
 
-function unpack_solution(simsol::SciMLBase.AbstractEnsembleSolution{T,N,V}) where {T,N,V}
-    map(unpack_solution, simsol)
-end
+unpack_solution(simsol::SciMLBase.AbstractEnsembleSolution) = map(unpack_solution, simsol.u)

--- a/src/GradusBase/metric-params.jl
+++ b/src/GradusBase/metric-params.jl
@@ -24,9 +24,9 @@ Return a tuple with each non-zero metric component for the metric described by `
 only be a subset of the total manifold coordinates. See specific implementations for subtypes of
 [`AbstractMetricParams`](@ref) for details.
 """
-metric_components(m::AbstractMetricParams{T}, x) where {T} =
+metric_components(m::AbstractMetricParams, x) =
     error("Not implemented for metric $(typeof(m))")
-inverse_metric_components(m::AbstractMetricParams{T}, x) where {T} =
+inverse_metric_components(m::AbstractMetricParams, x) =
     error("Not implemented for metric $(typeof(m))")
 
 """
@@ -35,9 +35,9 @@ inverse_metric_components(m::AbstractMetricParams{T}, x) where {T} =
 
 Calculate the acceleration components of the geodesic equation given a position `u`, a velocity `v`, and a metric `m`.
 """
-geodesic_eq(m::AbstractMetricParams{T}, u, v) where {T} =
+geodesic_eq(m::AbstractMetricParams, u, v) =
     error("Not implemented for metric parameters $(typeof(m))")
-geodesic_eq!(m::AbstractMetricParams{T}, u, v) where {T} =
+geodesic_eq!(m::AbstractMetricParams, u, v) =
     error("Not implemented for metric parameters $(typeof(m))")
 
 """
@@ -64,7 +64,7 @@ inner_radius(::AbstractMetricParams{T}) where {T} = convert(T, 0.0)
 
 Return the [`AbstractMetric`](@ref) type associated with the metric parameters `m`.
 """
-metric_type(m::AbstractMetricParams{T}) where {T} =
+metric_type(m::AbstractMetricParams) =
     error("Not implemented for metric parameters $(typeof(m))")
 
 
@@ -74,14 +74,4 @@ metric_type(m::AbstractMetricParams{T}) where {T} =
 Numerically evaluate the corresponding metric for [`AbstractMetricParams`](@ref), given parameter values `m`
 and some point `u`.
 """
-metric(m::AbstractMetricParams{T}, u) where {T} =
-    error("Not implemented for metric $(typeof(m))")
-
-# do we actually want to support this?
-# since if it's a symbolic matrix, you can subs other ways better?
-#"""
-#    metric(m::AbstractMetric{T}, u)
-#
-#Evaluate the metric at a point `u`.
-#"""
-#metric(m::AbstractMetric{T}, u) where {T} = error("Not implemented for metric $(typeof(m))")
+metric(m::AbstractMetricParams, u) = error("Not implemented for metric $(typeof(m))")

--- a/src/GradusBase/physical-quantities.jl
+++ b/src/GradusBase/physical-quantities.jl
@@ -19,8 +19,8 @@ the mass ``\\mu`` needs to be known to compute ``\\mu v^\\nu = p^\\nu``.
 function E(metric::AbstractMatrix{T}, v) where {T}
     T(@inbounds -(metric[1, 1] * v[1] + metric[1, 4] * v[4]))
 end
-E(m::AbstractMetricParams{T}, u, v) where {T} = E(metric(m, u), v)
-E(m::AbstractMetricParams{T}, gp::AbstractGeodesicPoint) where {T} = E(m, gp.u2, gp.v2)
+E(m::AbstractMetricParams, u, v) = E(metric(m, u), v)
+E(m::AbstractMetricParams, gp::AbstractGeodesicPoint) = E(m, gp.u2, gp.v2)
 
 
 """
@@ -35,5 +35,5 @@ L_z = p_\\phi = - g_{\\phi\\nu} p^\\nu.
 function Lz(metric::AbstractMatrix{T}, v) where {T}
     T(@inbounds metric[4, 4] * v[4] + metric[1, 4] * v[1])
 end
-Lz(m::AbstractMetricParams{T}, u, v) where {T} = Lz(metric(m, u), v)
-Lz(m::AbstractMetricParams{T}, gp::AbstractGeodesicPoint) where {T} = Lz(m, gp.u2, gp.v2)
+Lz(m::AbstractMetricParams, u, v) = Lz(metric(m, u), v)
+Lz(m::AbstractMetricParams, gp::AbstractGeodesicPoint) = Lz(m, gp.u2, gp.v2)

--- a/src/accretion-geometry/bootstrap.jl
+++ b/src/accretion-geometry/bootstrap.jl
@@ -1,13 +1,13 @@
 function tracegeodesics(
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     init_positions,
     init_velocities,
     accretion_geometry::AbstractAccretionGeometry,
-    time_domain::Tuple{T,T};
+    time_domain::NTuple{2};
     callback = nothing,
     gtol = 1e-2,
     kwargs...,
-) where {T}
+)
     cbs = add_collision_callback(callback, accretion_geometry; gtol = gtol)
     tracegeodesics(
         m,
@@ -20,27 +20,27 @@ function tracegeodesics(
 end
 
 function rendergeodesics(
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     init_pos,
     accretion_geometry::AbstractAccretionGeometry,
-    max_time::T;
+    max_time::Number;
     callback = nothing,
     gtol = 1e-2,
     kwargs...,
-) where {T}
+)
     cbs = add_collision_callback(callback, accretion_geometry; gtol = gtol)
     rendergeodesics(m, init_pos, max_time; callback = cbs, kwargs...)
 end
 
 function prerendergeodesics(
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     init_pos,
     accretion_geometry::AbstractAccretionGeometry,
-    max_time::T;
+    max_time::Number;
     callback = nothing,
     gtol = 1e-2,
     kwargs...,
-) where {T}
+)
     cbs = add_collision_callback(callback, accretion_geometry; gtol = gtol)
     prerendergeodesics(m, init_pos, max_time; callback = cbs, kwargs...)
 end
@@ -62,7 +62,7 @@ function callback(u, λ, integrator)::Bool
 end
 ```
 """
-function build_collision_callback(g::AbstractAccretionGeometry{T}; gtol) where {T}
+function build_collision_callback(g::AbstractAccretionGeometry; gtol)
     DiscreteCallback(
         (u, λ, integrator) ->
             intersects_geometry(g, line_element(u, integrator), integrator),

--- a/src/const-point-functions.jl
+++ b/src/const-point-functions.jl
@@ -10,7 +10,7 @@ using ..Gradus:
     FilterPointFunction,
     _redshift_guard,
     StatusCodes,
-    KerrSpacetime,
+    KerrMetric,
     KerrSpacetimeFirstOrder,
     AbstractMetricParams,
     interpolate_redshift
@@ -60,14 +60,14 @@ Returns a [`PointFunction`](@ref).
 Calculate the analytic redshift at a given geodesic point, assuming equitorial, geometrically
 thin accretion disc. Implementation depends on the metric type. Currently implemented for
 
-- [`Gradus.KerrSpacetime`](@ref)
+- [`Gradus.KerrMetric`](@ref)
 - [`Gradus.KerrSpacetimeFirstOrder`](@ref)
 
 # Notes
 
 Wraps calls to [`Gradus._redshift_guard`](@ref) to dispatch different implementations.
 """
-redshift(::KerrSpacetime, _) = PointFunction(_redshift_guard)
+redshift(::KerrMetric, _) = PointFunction(_redshift_guard)
 redshift(::KerrSpacetimeFirstOrder, _) = PointFunction(_redshift_guard)
 redshift(m::AbstractMetricParams, u; kwargs...) = interpolate_redshift(m, u; kwargs...)
 

--- a/src/const-point-functions.jl
+++ b/src/const-point-functions.jl
@@ -5,7 +5,15 @@ Module defining a number of `const` [`Gradus.AbstractPointFunction`](@ref), serv
 or common purposes for analysis.
 """
 module ConstPointFunctions
-using ..Gradus: PointFunction, FilterPointFunction, _redshift_guard, StatusCodes
+using ..Gradus:
+    PointFunction,
+    FilterPointFunction,
+    _redshift_guard,
+    StatusCodes,
+    BoyerLindquistAD,
+    BoyerLindquistFO,
+    AbstractMetricParams,
+    interpolate_redshift
 # for doc bindings
 import ..Gradus
 
@@ -45,7 +53,9 @@ Equivalent to `ConstPointFunctions.affine_time ∘ ConstPointFunctions.filter_ea
 const shadow = affine_time ∘ filter_early_term
 
 """
-    redshift(m::AbstractMetricParams, gp::AbstractGeodesicPoint, max_time)
+    redshift(m::AbstractMetricParams)
+
+Returns a [`PointFunction`](@ref).
 
 Calculate the analytic redshift at a given geodesic point, assuming equitorial, geometrically
 thin accretion disc. Implementation depends on the metric type. Currently implemented for
@@ -57,7 +67,9 @@ thin accretion disc. Implementation depends on the metric type. Currently implem
 
 Wraps calls to [`Gradus._redshift_guard`](@ref) to dispatch different implementations.
 """
-const redshift = PointFunction(_redshift_guard)
+redshift(::BoyerLindquistAD, _) = PointFunction(_redshift_guard)
+redshift(::BoyerLindquistFO, _) = PointFunction(_redshift_guard)
+redshift(m::AbstractMetricParams, u; kwargs...) = interpolate_redshift(m, u; kwargs...)
 
 end # module
 

--- a/src/const-point-functions.jl
+++ b/src/const-point-functions.jl
@@ -10,8 +10,8 @@ using ..Gradus:
     FilterPointFunction,
     _redshift_guard,
     StatusCodes,
-    BoyerLindquistAD,
-    BoyerLindquistFO,
+    KerrSpacetime,
+    KerrSpacetimeFirstOrder,
     AbstractMetricParams,
     interpolate_redshift
 # for doc bindings
@@ -60,15 +60,15 @@ Returns a [`PointFunction`](@ref).
 Calculate the analytic redshift at a given geodesic point, assuming equitorial, geometrically
 thin accretion disc. Implementation depends on the metric type. Currently implemented for
 
-- [`Gradus.BoyerLindquistAD`](@ref)
-- [`Gradus.BoyerLindquistFO`](@ref)
+- [`Gradus.KerrSpacetime`](@ref)
+- [`Gradus.KerrSpacetimeFirstOrder`](@ref)
 
 # Notes
 
 Wraps calls to [`Gradus._redshift_guard`](@ref) to dispatch different implementations.
 """
-redshift(::BoyerLindquistAD, _) = PointFunction(_redshift_guard)
-redshift(::BoyerLindquistFO, _) = PointFunction(_redshift_guard)
+redshift(::KerrSpacetime, _) = PointFunction(_redshift_guard)
+redshift(::KerrSpacetimeFirstOrder, _) = PointFunction(_redshift_guard)
 redshift(m::AbstractMetricParams, u; kwargs...) = interpolate_redshift(m, u; kwargs...)
 
 end # module

--- a/src/corona-to-disc/corona-models.jl
+++ b/src/corona-to-disc/corona-models.jl
@@ -3,11 +3,7 @@ function source_velocity(::AbstractMetricParams, model::AbstractCoronaModel)
     error("Not implemented for $(typeof(model)).")
 end
 
-function sample_position(
-    ::AbstractMetricParams{T},
-    model::AbstractCoronaModel{T},
-    N,
-) where {T}
+function sample_position(::AbstractMetricParams, model::AbstractCoronaModel, N)
     error("Not implemented for $(typeof(model)).")
 end
 

--- a/src/corona-to-disc/disc-profiles.jl
+++ b/src/corona-to-disc/disc-profiles.jl
@@ -1,45 +1,30 @@
 function tracegeodesics(
-    m::AbstractMetricParams{T},
-    model::AbstractCoronaModel{T},
-    time_domain::Tuple{T,T};
+    m::AbstractMetricParams,
+    model::AbstractCoronaModel,
+    time_domain::NTuple{2},
     n_samples = 1024,
     sampler = WeierstrassSampler(res = 100.0),
     kwargs...,
-) where {T}
+)
     us = sample_position(m, model, n_samples)
     vs = sample_velocity(m, model, sampler, us, n_samples)
     tracegeodesics(m, us, vs, time_domain; kwargs...)
 end
 
 function tracegeodesics(
-    m::AbstractMetricParams{T},
-    model::AbstractCoronaModel{T},
-    d::AbstractAccretionGeometry{T},
-    time_domain::Tuple{T,T},
+    m::AbstractMetricParams,
+    model::AbstractCoronaModel,
+    d::AbstractAccretionGeometry,
+    time_domain::NTuple{2},
     ;
     n_samples = 1024,
     sampler = WeierstrassSampler(res = 100.0),
     kwargs...,
-) where {T}
+)
     us = sample_position(m, model, n_samples)
     vs = sample_velocity(m, model, sampler, us, n_samples)
     tracegeodesics(m, us, vs, d, time_domain; kwargs...)
 end
-
-function renderprofile(
-    m::AbstractMetricParams{T},
-    model::AbstractCoronaModel{T},
-    d::AbstractAccretionGeometry{T},
-    max_time::T;
-    n_samples = 1024,
-    sampler = WeierstrassSampler(res = 100.0),
-    kwargs...,
-) where {T}
-    __renderprofile(m, model, d, n_samples, (0.0, max_time); kwargs...)
-end
-
-# evaluate(aap::AbstractAccretionProfile, p) =
-#     error("Not implemented for `$(typeof(aap))` yet.")
 
 struct VoronoiDiscProfile{D,V,G} <: AbstractDiscProfile
     disc::D
@@ -62,7 +47,7 @@ struct VoronoiDiscProfile{D,V,G} <: AbstractDiscProfile
     end
 end
 
-function Base.show(io::IO, vdp::VoronoiDiscProfile{D,T}) where {D,T}
+function Base.show(io::IO, vdp::VoronoiDiscProfile{D}) where {D}
     write(io, "VoronoiDiscProfile for $D with $(length(vdp.generators)) generators")
 end
 
@@ -94,18 +79,18 @@ function VoronoiDiscProfile(
 end
 
 function VoronoiDiscProfile(
-    m::AbstractMetricParams{T},
-    d::AbstractAccretionDisc{T},
+    m::AbstractMetricParams,
+    d::AbstractAccretionDisc,
     sols::AbstractArray{S},
-) where {T,S<:SciMLBase.AbstractODESolution}
+) where {S<:SciMLBase.AbstractODESolution}
     VoronoiDiscProfile(m, d, map(sol -> getgeodesicpoint(m, sol), sols))
 end
 
 function VoronoiDiscProfile(
-    m::AbstractMetricParams{T},
-    d::AbstractAccretionDisc{T},
-    simsols::SciMLBase.EnsembleSolution{T},
-) where {T}
+    m::AbstractMetricParams,
+    d::AbstractAccretionDisc,
+    simsols::SciMLBase.EnsembleSolution,
+)
     VoronoiDiscProfile(
         m,
         d,
@@ -113,10 +98,11 @@ function VoronoiDiscProfile(
     )
 end
 
-@noinline function findindex(vdp::VoronoiDiscProfile{D,V}, p) where {D,V}
+@noinline function findindex(vdp::VoronoiDiscProfile, p)
     for (i, poly) in enumerate(vdp.polys)
         # check if we're at all close
         let p1 = poly[1]
+            # todo: what's going on here?
             d = @inbounds (p1[1] - p[1])^2 + (p1[2] - p[2])^2
 
             if inpolygon(poly, p)
@@ -127,19 +113,12 @@ end
     -1
 end
 
-@inline function findindex(
-    vdp::VoronoiDiscProfile{D,V},
-    gp::GeodesicPoint{T,P},
-) where {D,V,T,P}
+@inline function findindex(vdp::VoronoiDiscProfile, gp::GeodesicPoint)
     p = to_cartesian(gp)
     findindex(vdp, p)
 end
 
-function findindex(
-    vdp::VoronoiDiscProfile{D,V},
-    gps::AbstractArray{GeodesicPoint{T,P}};
-    kwargs...,
-) where {D,V,T,P}
+function findindex(vdp::VoronoiDiscProfile, gps::AbstractArray{<:GeodesicPoint}; kwargs...)
     ret = fill(-1, size(gps))
     Threads.@threads for i = 1:length(gps)
         gp = gps[i]
@@ -148,12 +127,9 @@ function findindex(
     ret
 end
 
-getareas(vdp::VoronoiDiscProfile{D,T}) where {D,T} = getarea.(vdp.polys)
+getareas(vdp::VoronoiDiscProfile) = getarea.(vdp.polys)
 
-function getproperarea(
-    poly::P,
-    m::AbstractMetricParams{T},
-) where {P<:AbstractArray{V}} where {V,T}
+function getproperarea(poly::AbstractArray, m::AbstractMetricParams)
     A = getarea(poly)
     c = getbarycenter(poly)
     # get value of metric at the radius of the polygon's barycenter, and in the equitorial plane
@@ -162,7 +138,7 @@ function getproperarea(
     sqrt(m_params[2] * m_params[4]) * A
 end
 
-getproperarea(vdp::VoronoiDiscProfile{D,K}, m::AbstractMetricParams{T}) where {D,K,T} =
+getproperarea(vdp::VoronoiDiscProfile, m::AbstractMetricParams) =
     map(p -> getproperarea(p, m), vdp.polys)
 
 function unpack_polys(
@@ -180,10 +156,10 @@ end
 
 function SurrogateDiscProfile(
     disc::D,
-    x::AbstractArray{SVector{N,T}},
+    x::AbstractArray{<:SVector{N}},
     y;
     S = Surrogates.RadialBasis,
-) where {D,N,T}
+) where {D,N}
     bounds = map(1:N) do i
         extrema(el -> el[i], x)
     end
@@ -207,6 +183,7 @@ function Base.show(io::IO, ::MIME"text/plain", sdp::SurrogateDiscProfile{D,S}) w
         "SurrogateDiscProfile\n - disc      : $D\n - surrogate : $(Base.typename(S).name) ($(length(sdp.surrogate.x)) points)",
     )
 end
+
 """
     getbarycenter(poly)
 
@@ -225,7 +202,6 @@ function getbarycenter(poly)
     n = length(poly)
     SVector{2}(xs / n, ys / n)
 end
-
 
 """
     cutchart!(polys, m::AbstractMetricParams{T}, d::AbstractAccretionDisc{T})
@@ -289,10 +265,7 @@ function _circ_cut(radius, clines, i1, t1, i2, t2; outer = true)
     end
 end
 
-function _circ_path_intersect(
-    radius,
-    lines::AbstractArray{L},
-) where {L<:GeometryBasics.Line}
+function _circ_path_intersect(radius, lines::AbstractArray{<:GeometryBasics.Line})
     for (i, line) in enumerate(lines)
         t = _circ_line_intersect(radius, line)
         if t > 0
@@ -323,18 +296,6 @@ end
         end
     end
     -1
-end
-
-function __renderprofile(
-    m::AbstractMetricParams{T},
-    model::AbstractCoronaModel{T},
-    d::AbstractAccretionGeometry{T},
-    time_domain;
-    sampler,
-    kwargs...,
-) where {T}
-    # TODO
-    error("Not implemented for $(typeof(d)).")
 end
 
 export VoronoiDiscProfile,

--- a/src/corona-to-disc/disc-profiles.jl
+++ b/src/corona-to-disc/disc-profiles.jl
@@ -83,7 +83,7 @@ function VoronoiDiscProfile(
     d::AbstractAccretionDisc,
     sols::AbstractArray{S},
 ) where {S<:SciMLBase.AbstractODESolution}
-    VoronoiDiscProfile(m, d, map(sol -> getgeodesicpoint(m, sol), sols))
+    VoronoiDiscProfile(m, d, map(sol -> process_solution(m, sol), sols))
 end
 
 function VoronoiDiscProfile(

--- a/src/corona-to-disc/flux-calculations.jl
+++ b/src/corona-to-disc/flux-calculations.jl
@@ -33,9 +33,9 @@ function flux_source_to_disc(
     m::AbstractMetricParams,
     model::AbstractCoronaModel,
     points,
-    areas::AbstractVector{T};
+    areas::AbstractVector;
     α = 1.0,
-) where {T}
+)
     v_source = source_velocity(m, model)
 
     total_area = sum(areas)

--- a/src/corona-to-disc/sky-geometry.jl
+++ b/src/corona-to-disc/sky-geometry.jl
@@ -41,7 +41,7 @@ sample_angles(sm::AbstractDirectionSampler{D,G}, i, N) where {D,G} =
     (sample_elevation(sm, i), mod2pi(getangle(sm, i)))
 
 
-sample_elevation(sm::AbstractDirectionSampler{D,G}, i) where {D,G} =
+sample_elevation(sm::AbstractDirectionSampler, i) =
     error("Not implemented for $(typeof(sm)).")
 @inline sample_elevation(::EvenSampler{LowerHemisphere}, i) = acos(1 - i)
 @inline sample_elevation(::EvenSampler{BothHemispheres}, i) = acos(1 - 2i)

--- a/src/image-planes/planes.jl
+++ b/src/image-planes/planes.jl
@@ -1,6 +1,7 @@
 abstract type AbstractImagePlane{G} end
 image_plane(plane::AbstractImagePlane, u) = error("Not implemented for $plane")
 trajectory_count(plane::AbstractImagePlane) = error("Not implemented for $plane")
+unnormalized_areas(plane::AbstractImagePlane) = error("Not implemented for $plane")
 
 function impact_parameters(plane::AbstractImagePlane, u)
     αs, βs = image_plane(plane, u)
@@ -42,6 +43,15 @@ function image_plane(plane::PolarPlane, u)
     βs = [r * sin(θ) * sin(u[3]) for r in rs, θ in θs]
 
     αs, βs
+end
+
+function unnormalized_areas(plane::PolarPlane)
+    rs = collect(plane.grid(plane.r_min, plane.r_max, plane.Nr))
+    # todo: do we need dr here?
+    # dr = diff(rs) 
+    # push!(dr, 0.0)
+    A = @. rs^2 # * abs(dr)
+    repeat(A, inner = (1, plane.Nθ))
 end
 
 struct CartesianPlane{G,T} <: AbstractImagePlane{G}
@@ -89,12 +99,12 @@ function image_plane(plane::CartesianPlane, u)
 end
 
 function tracegeodesics(
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     observer_position,
     plane::AbstractImagePlane,
-    time_domain::Tuple{T,T};
+    time_domain::NTuple{2};
     kwargs...,
-) where {T}
+)
     αs, βs = impact_parameters(plane, observer_position)
     velfunc(i) = map_impact_parameters(m, observer_position, αs[i], βs[i])
     tracegeodesics(

--- a/src/line-profiles.jl
+++ b/src/line-profiles.jl
@@ -11,16 +11,17 @@ struct BinnedLineProfile <: AbstractLineProfileAlgorithm end
     algorithm::AbstractLineProfileAlgorithm = CunninghamLineProfile(),
     kwargs...,
 )
-    lineprofile(bins, algorithm, m, u, d, ε; kwargs...)
+    lineprofile(bins, ε, m, u, d, algorithm; kwargs...)
 end
 
 function lineprofile(
     bins,
-    ::CunninghamLineProfile,
+    ε::Function,
     m::AbstractMetricParams{T},
     u,
     d::AbstractAccretionGeometry,
-    ε;
+    ::CunninghamLineProfile,
+    ;
     minrₑ = isco(m) + 1e-2, # delta to avoid numerical instabilities
     maxrₑ = 50,
     numrₑ = 100,

--- a/src/metrics/boyer-lindquist-ad.jl
+++ b/src/metrics/boyer-lindquist-ad.jl
@@ -31,7 +31,7 @@ end # module
 
 # new structure for our spacetime
 """
-    struct BoyerLindquistAD{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+    struct KerrSpacetime{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
 
 The Kerr metric in Boyer-Lindquist coordinates, describing a black hole with mass ``M`` and
 angular spin ``a``:
@@ -57,7 +57,7 @@ where
 ## Parameters
 $(FIELDS)
 """
-@with_kw struct BoyerLindquistAD{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+@with_kw struct KerrSpacetime{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
     @deftype T
     "Black hole mass."
     M = 1.0
@@ -66,9 +66,9 @@ $(FIELDS)
 end
 
 # implementation
-metric_components(m::BoyerLindquistAD{T}, rθ) where {T} =
+metric_components(m::KerrSpacetime{T}, rθ) where {T} =
     __BoyerLindquistAD.metric_components(m.M, m.a, rθ)
-inner_radius(m::BoyerLindquistAD{T}) where {T} = m.M + √(m.M^2 - m.a^2)
+inner_radius(m::KerrSpacetime{T}) where {T} = m.M + √(m.M^2 - m.a^2)
 
 # additional utilities
 function convert_angles(a, r, θ, ϕ, θ_obs, ϕ_obs)
@@ -82,11 +82,11 @@ function convert_angles(a, r, θ, ϕ, θ_obs, ϕ_obs)
 end
 
 # for disc profile models
-function GradusBase.vector_to_local_sky(m::BoyerLindquistAD{T}, u, θ, ϕ) where {T}
+function GradusBase.vector_to_local_sky(m::KerrSpacetime{T}, u, θ, ϕ) where {T}
     convert_angles(m.a, u[2], u[3], u[4], θ, ϕ)
 end
 
 # special radii
-isco(m::BoyerLindquistAD{T}) where {T} = __BoyerLindquistFO.isco(m.M, m.a)
+isco(m::KerrSpacetime{T}) where {T} = __BoyerLindquistFO.isco(m.M, m.a)
 
-export BoyerLindquistAD
+export KerrSpacetime

--- a/src/metrics/boyer-lindquist-ad.jl
+++ b/src/metrics/boyer-lindquist-ad.jl
@@ -31,7 +31,7 @@ end # module
 
 # new structure for our spacetime
 """
-    struct KerrSpacetime{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+    struct KerrMetric{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
 
 The Kerr metric in Boyer-Lindquist coordinates, describing a black hole with mass ``M`` and
 angular spin ``a``:
@@ -57,7 +57,7 @@ where
 ## Parameters
 $(FIELDS)
 """
-@with_kw struct KerrSpacetime{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+@with_kw struct KerrMetric{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
     @deftype T
     "Black hole mass."
     M = 1.0
@@ -66,9 +66,9 @@ $(FIELDS)
 end
 
 # implementation
-metric_components(m::KerrSpacetime{T}, rθ) where {T} =
+metric_components(m::KerrMetric{T}, rθ) where {T} =
     __BoyerLindquistAD.metric_components(m.M, m.a, rθ)
-inner_radius(m::KerrSpacetime{T}) where {T} = m.M + √(m.M^2 - m.a^2)
+inner_radius(m::KerrMetric{T}) where {T} = m.M + √(m.M^2 - m.a^2)
 
 # additional utilities
 function convert_angles(a, r, θ, ϕ, θ_obs, ϕ_obs)
@@ -82,11 +82,11 @@ function convert_angles(a, r, θ, ϕ, θ_obs, ϕ_obs)
 end
 
 # for disc profile models
-function GradusBase.vector_to_local_sky(m::KerrSpacetime{T}, u, θ, ϕ) where {T}
+function GradusBase.vector_to_local_sky(m::KerrMetric{T}, u, θ, ϕ) where {T}
     convert_angles(m.a, u[2], u[3], u[4], θ, ϕ)
 end
 
 # special radii
-isco(m::KerrSpacetime{T}) where {T} = __BoyerLindquistFO.isco(m.M, m.a)
+isco(m::KerrMetric{T}) where {T} = __BoyerLindquistFO.isco(m.M, m.a)
 
-export KerrSpacetime
+export KerrMetric

--- a/src/metrics/boyer-lindquist-fo.jl
+++ b/src/metrics/boyer-lindquist-fo.jl
@@ -338,10 +338,10 @@ isco(M, a) = a > 0.0 ? isco(M, a, -) : isco(M, a, +)
 end # module
 
 """
-A first-order implementation of [`BoyerLindquistAD`](@ref).
+A first-order implementation of [`KerrSpacetime`](@ref).
 $(FIELDS)
 """
-@with_kw struct BoyerLindquistFO{T} <: AbstractFirstOrderMetricParams{T}
+@with_kw struct KerrSpacetimeFirstOrder{T} <: AbstractFirstOrderMetricParams{T}
     @deftype T
     "Black hole mass."
     M = 1.0
@@ -351,31 +351,31 @@ $(FIELDS)
     E = 1.0
 end
 
-GradusBase.inner_radius(m::BoyerLindquistFO{T}) where {T} = m.M + √(m.M^2 - m.a^2)
-GradusBase.constrain(::BoyerLindquistFO{T}, u, v; μ = 0.0) where {T} = v[1]
+GradusBase.inner_radius(m::KerrSpacetimeFirstOrder{T}) where {T} = m.M + √(m.M^2 - m.a^2)
+GradusBase.constrain(::KerrSpacetimeFirstOrder{T}, u, v; μ = 0.0) where {T} = v[1]
 
-four_velocity(u, m::BoyerLindquistFO{T}, p) where {T} =
+four_velocity(u, m::KerrSpacetimeFirstOrder{T}, p) where {T} =
     __BoyerLindquistFO.four_velocity(u, m.E, m.M, m.a, p)
-calc_lq(m::BoyerLindquistFO{T}, pos, vel) where {T} =
+calc_lq(m::KerrSpacetimeFirstOrder{T}, pos, vel) where {T} =
     __BoyerLindquistFO.LQ(m.M, pos[2], m.a, pos[3], vel[3], vel[4])
 
-function Vr(m::BoyerLindquistFO{T}, u, p) where {T}
+function Vr(m::KerrSpacetimeFirstOrder{T}, u, p) where {T}
     L = p.L
     Q = p.Q
     __BoyerLindquistFO.Vr(m.E, L, m.M, Q, u[2], m.a)
 end
-function Vθ(m::BoyerLindquistFO{T}, u, p) where {T}
+function Vθ(m::KerrSpacetimeFirstOrder{T}, u, p) where {T}
     L = p.L
     Q = p.Q
     __BoyerLindquistFO.Vθ(m.E, L, Q, m.a, u[3])
 end
 
-function impact_parameters_to_vel(m::BoyerLindquistFO{T}, u, α, β) where {T}
+function impact_parameters_to_vel(m::KerrSpacetimeFirstOrder{T}, u, α, β) where {T}
     sinΦ, sinΨ = __BoyerLindquistFO.sinΦsinΨ(m.M, u[2], m.a, u[3], α, β)
     (β < 0.0 ? 1.0 : -1.0, sinΦ, sinΨ)
 end
 
 # special radii
-isco(m::BoyerLindquistFO{T}) where {T} = __BoyerLindquistFO.isco(m.M, m.a)
+isco(m::KerrSpacetimeFirstOrder{T}) where {T} = __BoyerLindquistFO.isco(m.M, m.a)
 
-export BoyerLindquistFO
+export KerrSpacetimeFirstOrder

--- a/src/metrics/boyer-lindquist-fo.jl
+++ b/src/metrics/boyer-lindquist-fo.jl
@@ -338,7 +338,7 @@ isco(M, a) = a > 0.0 ? isco(M, a, -) : isco(M, a, +)
 end # module
 
 """
-A first-order implementation of [`KerrSpacetime`](@ref).
+A first-order implementation of [`KerrMetric`](@ref).
 $(FIELDS)
 """
 @with_kw struct KerrSpacetimeFirstOrder{T} <: AbstractFirstOrderMetricParams{T}

--- a/src/metrics/dilaton-axion-ad.jl
+++ b/src/metrics/dilaton-axion-ad.jl
@@ -47,12 +47,12 @@ end
 end # module
 
 """
-    struct DilatonAxionAD{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+    struct DilatonAxion{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
 
 Einstein-Maxwell-Dilaton-Axion metric.
 $(FIELDS)
 """
-@with_kw struct DilatonAxionAD{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+@with_kw struct DilatonAxion{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
     @deftype T
     "Singularity mass."
     M = 1.0
@@ -64,8 +64,8 @@ $(FIELDS)
     b = 1.0
 end
 
-metric_components(m::DilatonAxionAD{T}, rθ) where {T} =
+metric_components(m::DilatonAxion{T}, rθ) where {T} =
     __DilatonAxionAD.metric_components(m.M, m.a, m.β, m.b, rθ)
-GradusBase.inner_radius(m::DilatonAxionAD{T}) where {T} = m.M + √(m.M^2 - m.a^2)
+GradusBase.inner_radius(m::DilatonAxion{T}) where {T} = m.M + √(m.M^2 - m.a^2)
 
-export DilatonAxionAD
+export DilatonAxion

--- a/src/metrics/johannsen-ad.jl
+++ b/src/metrics/johannsen-ad.jl
@@ -36,12 +36,12 @@ end
 end # module
 
 """
-    struct JohannsenAD{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+    struct JohannsenMetric{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
 
 The Johannsen (20xx) metric.
 $(FIELDS)
 """
-@with_kw struct JohannsenAD{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+@with_kw struct JohannsenMetric{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
     @deftype T
     "Black hole mass."
     M = 1.0
@@ -57,7 +57,7 @@ $(FIELDS)
     ϵ3 = 0.0
 end
 
-metric_components(m::JohannsenAD{T}, rθ) where {T} = __JohannsenAD.metric_components(m, rθ)
-GradusBase.inner_radius(m::JohannsenAD{T}) where {T} = m.M + √(m.M^2 - m.a^2)
+metric_components(m::JohannsenMetric{T}, rθ) where {T} = __JohannsenAD.metric_components(m, rθ)
+GradusBase.inner_radius(m::JohannsenMetric{T}) where {T} = m.M + √(m.M^2 - m.a^2)
 
-export JohannsenAD
+export JohannsenMetric

--- a/src/metrics/johannsen-psaltis-ad.jl
+++ b/src/metrics/johannsen-psaltis-ad.jl
@@ -28,12 +28,12 @@ end
 end # module
 
 """
-    struct JohannsenPsaltisAD{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+    struct JohannsenPsaltisMetric{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
 
 Johannsen and Psaltis 2011
 $(FIELDS)
 """
-@with_kw struct JohannsenPsaltisAD{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+@with_kw struct JohannsenPsaltisMetric{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
     @deftype T
     "Black hole mass."
     M = 1.0
@@ -43,8 +43,8 @@ $(FIELDS)
     ϵ3 = 0.0
 end
 
-metric_components(m::JohannsenPsaltisAD{T}, rθ) where {T} =
+metric_components(m::JohannsenPsaltisMetric{T}, rθ) where {T} =
     __JohannsenPsaltisAD.metric_components(m.M, m.a, m.ϵ3, rθ)
-GradusBase.inner_radius(m::JohannsenPsaltisAD{T}) where {T} = m.M + √(m.M^2 - m.a^2)
+GradusBase.inner_radius(m::JohannsenPsaltisMetric{T}) where {T} = m.M + √(m.M^2 - m.a^2)
 
-export JohannsenPsaltisAD
+export JohannsenPsaltisMetric

--- a/src/metrics/kerr-refractive-ad.jl
+++ b/src/metrics/kerr-refractive-ad.jl
@@ -41,13 +41,13 @@ end
 end # module
 
 """
-    struct KerrRefractiveAD{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+    struct KerrRefractive{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
 
 Kerr metric in Boyer-Lindquist coordintes with a path-length ansatz, equivalent to a refractive
 index `n`, within the coronal radius `corona_radius`.
 $(FIELDS)
 """
-@with_kw struct KerrRefractiveAD{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+@with_kw struct KerrRefractive{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
     @deftype T
     "Black hole mass."
     M = 1.0
@@ -60,11 +60,11 @@ $(FIELDS)
 end
 
 # implementation
-metric_components(m::KerrRefractiveAD{T}, rθ) where {T} =
+metric_components(m::KerrRefractive{T}, rθ) where {T} =
     __KerrRefractiveAD.metric_components(m.M, m.a, m.n, m.corona_radius, rθ)
-GradusBase.inner_radius(m::KerrRefractiveAD{T}) where {T} = m.M + √(m.M^2 - m.a^2)
+GradusBase.inner_radius(m::KerrRefractive{T}) where {T} = m.M + √(m.M^2 - m.a^2)
 
 # special radii
-isco(m::KerrRefractiveAD{T}) where {T} = __BoyerLindquistFO.isco(m.M, m.a)
+isco(m::KerrRefractive{T}) where {T} = __BoyerLindquistFO.isco(m.M, m.a)
 
-export KerrRefractiveAD
+export KerrRefractive

--- a/src/metrics/morris-thorne-ad.jl
+++ b/src/metrics/morris-thorne-ad.jl
@@ -17,21 +17,21 @@ end # module
 
 # new structure for our spacetime
 """
-    struct MorrisThorneAD{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+    struct MorrisThorneWormhole{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
 
 Morris-Thorne wormhole metric.
 
 $(FIELDS)
 """
-@with_kw struct MorrisThorneAD{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+@with_kw struct MorrisThorneWormhole{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
     @deftype T
     "Throat size."
     b = 1.0
 end
 
 # implementation
-metric_components(m::MorrisThorneAD{T}, rθ) where {T} =
+metric_components(m::MorrisThorneWormhole{T}, rθ) where {T} =
     __MorrisThorneAD.metric_components(m.b, rθ)
-GradusBase.inner_radius(m::MorrisThorneAD{T}) where {T} = 0.0
+GradusBase.inner_radius(m::MorrisThorneWormhole{T}) where {T} = 0.0
 
-export MorrisThorneAD
+export MorrisThorneWormhole

--- a/src/orbits/orbit-discovery.jl
+++ b/src/orbits/orbit-discovery.jl
@@ -13,20 +13,20 @@ function trace_single_orbit(m, r, vϕ; max_time = 300.0, μ = 1.0, tracer_args..
     Gradus.tracegeodesics(m, u, v, (0.0, max_time); μ = μ, tracer_args...)
 end
 
-function measure_stability(m::AbstractMetricParams{T}, r, vϕ; tracer_args...) where {T}
+function measure_stability(m::AbstractMetricParams, r, vϕ; tracer_args...)
     sol = trace_single_orbit(m, r, vϕ; tracer_args...)
     rs = selectdim(sol, 1, 2)
     Qs(rs)
 end
 
 function __solve_equitorial_circular_orbit(
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     r,
     optimizer,
     lower_bound,
     upper_bound;
     tracer_args...,
-) where {T}
+)
     res = optimize(
         vϕ -> measure_stability(m, r, vϕ; tracer_args...),
         lower_bound,
@@ -37,13 +37,13 @@ function __solve_equitorial_circular_orbit(
 end
 
 function solve_equitorial_circular_orbit(
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     r::Number;
     lower_bound = 0.0,
     upper_bound = 1.0,
     optimizer = GoldenSection(),
     tracer_args...,
-) where {T}
+)
     __solve_equitorial_circular_orbit(m, r, optimizer, lower_bound, upper_bound)
 end
 
@@ -56,16 +56,15 @@ function sliding_window(func, N, lower_bound, upper_bound, lower_rate, upper_rat
     end
 end
 
-
 function solve_equitorial_circular_orbit(
-    m::AbstractMetricParams{T},
-    r_range::Union{AbstractRange,AbstractArray};
+    m::AbstractMetricParams,
+    r_range::Union{<:AbstractRange,<:AbstractArray};
     lower_bound = 0.0,
     upper_bound = 1.0,
     lower_rate = 0.98,
     upper_rate = 1.5,
     kwargs...,
-) where {T}
+)
     r_range_reverse = sort(r_range) |> reverse
     candidate_vϕ = sliding_window(
         length(r_range_reverse),
@@ -85,11 +84,7 @@ function solve_equitorial_circular_orbit(
     reverse!(candidate_vϕ)
 end
 
-function trace_equitorial_circular_orbit(
-    m::AbstractMetricParams{T},
-    rs;
-    kwargs...,
-) where {T}
+function trace_equitorial_circular_orbit(m::AbstractMetricParams, rs; kwargs...)
     map(zip(rs, solve_equitorial_circular_orbit(m, rs; kwargs...))) do (r, vϕ)
         trace_single_orbit(m, r, vϕ; kwargs...)
     end

--- a/src/orbits/orbit-interpolations.jl
+++ b/src/orbits/orbit-interpolations.jl
@@ -29,7 +29,7 @@ function Base.show(io::IO, ::PlungingInterpolation{M}) where {M}
     write(io, "PlungingInterpolation for $M")
 end
 
-function (pintrp::PlungingInterpolation{M})(r) where {M}
+function (pintrp::PlungingInterpolation)(r)
     vt = pintrp.t(r)
     vr = pintrp.r(r)
     vϕ = pintrp.ϕ(r)

--- a/src/point-functions.jl
+++ b/src/point-functions.jl
@@ -93,7 +93,7 @@ end
 
 @inline function apply(pf::AbstractPointFunction, rc::SolutionRenderCache; kwargs...)
     ThreadsX.map(
-        sol -> pf.f(rc.m, getgeodesicpoint(m, sol), rc.max_time; kwargs...),
+        sol -> pf.f(rc.m, process_solution(m, sol), rc.max_time; kwargs...),
         rc.geodesics,
     )
 end

--- a/src/point-functions.jl
+++ b/src/point-functions.jl
@@ -72,7 +72,7 @@ A filter for geodesics within a certain radius, used to only calculate redshift 
 10 ``\\r_\\text{g}``
 ```julia
 func(m, gp, max_time) = gp.u[2] < 10.0
-pf = ConstPointFunctions.redshift ∘ FilterPointFunction(func, NaN64)
+pf = ConstPointFunctions.redshift(m, u) ∘ FilterPointFunction(func, NaN64)
 ```
 """
 struct FilterPointFunction{F,T} <: AbstractPointFunction
@@ -91,22 +91,14 @@ end
     convert(T, pf.f(m, gp, max_time; kwargs...))
 end
 
-@inline function apply(
-    pf::AbstractPointFunction,
-    rc::SolutionRenderCache{M,T,G};
-    kwargs...,
-) where {M,T,G}
+@inline function apply(pf::AbstractPointFunction, rc::SolutionRenderCache; kwargs...)
     ThreadsX.map(
         sol -> pf.f(rc.m, getgeodesicpoint(m, sol), rc.max_time; kwargs...),
         rc.geodesics,
     )
 end
 
-@inline function apply(
-    pf::AbstractPointFunction,
-    rc::EndpointRenderCache{M,T,P};
-    kwargs...,
-) where {M,T,P}
+@inline function apply(pf::AbstractPointFunction, rc::EndpointRenderCache; kwargs...)
     ThreadsX.map(gp -> pf.f(rc.m, gp, rc.max_time; kwargs...), rc.points)
 end
 
@@ -119,7 +111,7 @@ end
     end
 end
 
-@inline function Base.:∘(pf1::AbstractPointFunction, pf2::FilterPointFunction{F}) where {F}
+@inline function Base.:∘(pf1::AbstractPointFunction, pf2::FilterPointFunction)
     let f1 = pf1.f, f2 = pf2.f
         PointFunction(
             (m, gp, max_time; kwargs...) -> begin

--- a/src/redshift.jl
+++ b/src/redshift.jl
@@ -6,20 +6,24 @@ using Tullio: @tullio
 
 """
     eⱽ(M, r, a, θ)
+
 Modified from Cunningham et al. (1975) eq. (A2a):
+
 ```math
 e^\\nu = \\sqrt{\\frac{\\Delta \\Sigma}{A}}.
 ```
+
 """
 eⱽ(M, r, a, θ) = √(
     __BoyerLindquistFO.Σ(r, a, θ) * __BoyerLindquistFO.Δ(M, r, a) /
     __BoyerLindquistFO.A(M, r, a, θ),
 )
 
-
 """
     eᶲ(M, r, a, θ)
+
 Modified from Cunningham et al. (1975) eq. (A2b):
+
 ```math
 e^\\Phi = \\sin \\theta \\sqrt{\\frac{A}{\\Sigma}}.
 ```
@@ -27,49 +31,59 @@ e^\\Phi = \\sin \\theta \\sqrt{\\frac{A}{\\Sigma}}.
 eᶲ(M, r, a, θ) =
     sin(θ) * √(__BoyerLindquistFO.A(M, r, a, θ) / __BoyerLindquistFO.Σ(r, a, θ))
 
-
 """
     ω(M, r, a, θ)
+
 From Cunningham et al. (1975) eq. (A2c):
+
 ```math
 \\omega = \\frac{2 a M r}{A}.
 ```
 """
 ω(M, r, a, θ) = 2 * a * M * r / __BoyerLindquistFO.A(M, r, a, θ)
 
-
 """
     Ωₑ(M, r, a)
+
 Coordinate angular velocity of an accreting gas.
+
 Taken from Cunningham et al. (1975) eq. (A7b):
+
 ```math
 \\Omega_e = \\frac{\\sqrt{M}}{a \\sqrt{M} + r_e^{3/2}}.
 ```
+
 # Notes
+
 Fanton et al. (1997) use
+
 ```math
 \\Omega_e = \\frac{\\sqrt{M}}{a \\sqrt{M} \\pm r_e^{3/2}},
 ```
+
 where the sign is dependent on co- or contra-rotation. This function may be extended in the future to support this definition.
 """
 Ωₑ(M, r, a) = √M / (r^1.5 + a * √M)
 
-
 """
     Vₑ(M, r, a, θ)
+
 Velocity of an accreting gas in a locally non-rotating reference frame (see Bardeen et al. 1973).
 Taken from Cunningham et al. (1975) eq. (A7b):
+
 ```math
 V_e = (\\Omega_e - \\omega) e^{\\Phi - \\nu}.
 ```
 """
 Vₑ(M, r, a, θ) = (Ωₑ(M, r, a) - ω(M, r, a, θ)) * eᶲ(M, r, a, θ) / eⱽ(M, r, a, θ)
 
-
 """
     Lₑ(M, rms, a)
+
 Angular momentum of an accreting gas within ``r_ms``.
+
 Taken from Cunningham et al. (1975) eq. (A11b):
+
 ```math
 L_e = \\sqrt{M} \\frac{
         r_{\\text{ms}}^2 - 2 a \\sqrt{M r_{\\text{ms}}} + a^2
@@ -80,21 +94,24 @@ L_e = \\sqrt{M} \\frac{
 """
 Lₑ(M, rms, a) = √M * (rms^2 - 2 * a * √(M * rms) + a^2) / (rms^1.5 - 2 * M * √rms + a * √M)
 
-
 """
     H(M, rms, r, a)
+
 Taken from Cunningham et al. (1975) eq. (A12e):
+
 ```math
 H = \\frac{2 M r_e - a \\lambda_e}{\\Delta},
 ```
+
 where we distinguing ``r_e`` as the position of the accreting gas.
 """
 H(M, rms, r, a) = (2 * M * r - a * Lₑ(M, rms, a)) / __BoyerLindquistFO.Δ(M, r, a)
 
-
 """
     γₑ(M, rms)
+
 Taken from Cunningham et al. (1975) eq. (A11c):
+
 ```math
 \\gamma_e = \\sqrt{1 - \\frac{
         2M
@@ -105,10 +122,11 @@ Taken from Cunningham et al. (1975) eq. (A11c):
 """
 γₑ(M, rms) = √(1 - (2 * M) / (3 * rms))
 
-
 """
     uʳ(M, rms, r)
+
 Taken from Cunningham et al. (1975) eq. (A12b):
+
 ```math
 u^r = - \\sqrt{\\frac{
         2M
@@ -121,10 +139,11 @@ u^r = - \\sqrt{\\frac{
 """
 uʳ(M, rms, r) = -√((2 * M) / (3 * rms)) * (rms / r - 1)^1.5
 
-
 """
     uᶲ(M, rms, r, a)
+
 Taken from Cunningham et al. (1975) eq. (A12c):
+
 ```math
 u^\\phi = \\frac{\\gamma_e}{r_e^2} \\left(
         L_e + aH
@@ -133,10 +152,11 @@ u^\\phi = \\frac{\\gamma_e}{r_e^2} \\left(
 """
 uᶲ(M, rms, r, a) = γₑ(M, rms) / r^2 * (Lₑ(M, rms, a) + a * H(M, rms, r, a))
 
-
 """
     uᵗ(M, rms, r, a)
+
 Taken from Cunningham et al. (1975) eq. (A12b):
+
 ```math
 u^t = \\gamma_e \\left(
         1 + \\frac{2 M (1 + H)}{r_e}
@@ -145,15 +165,10 @@ u^t = \\gamma_e \\left(
 """
 uᵗ(M, rms, r, a) = γₑ(M, rms) * (1 + 2 * M * (1 + H(M, rms, r, a)) / r)
 
-
-"""
-Experimental API:
-"""
-function regular_pdotu_inv(L, M, r, a, θ)
+regular_pdotu_inv(L, M, r, a, θ) =
     (eⱽ(M, r, a, θ) * √(1 - Vₑ(M, r, a, θ)^2)) / (1 - L * Ωₑ(M, r, a))
-end
 
-@inline function regular_pdotu_inv(m::BoyerLindquistAD{T}, u, v) where {T}
+@inline function regular_pdotu_inv(m::BoyerLindquistAD, u, v)
     metric_matrix = metric(m, u)
 
     # TODO: this only works for Kerr
@@ -174,7 +189,7 @@ function plunging_p_dot_u(E, a, M, L, Q, rms, r, sign_r)
     )
 end
 
-function plunging_p_dot_u(m::AbstractMetricParams{T}, u, v, rms) where {T}
+function plunging_p_dot_u(m::BoyerLindquistAD, u, v, rms)
     metric_matrix = metric(m, u)
 
     # reverse signs of the velocity vector
@@ -192,7 +207,7 @@ function plunging_p_dot_u(m::AbstractMetricParams{T}, u, v, rms) where {T}
     1 / g
 end
 
-@inline function redshift_function(m::Gradus.BoyerLindquistFO{T}, u, p, λ) where {T}
+@inline function redshift_function(m::Gradus.BoyerLindquistFO, u, p, λ)
     isco = Gradus.isco(m)
     if u[2] > isco
         @inbounds regular_pdotu_inv(p.L, m.M, u[2], m.a, u[3])
@@ -207,7 +222,7 @@ end
     end
 end
 
-@inline function redshift_function(m::AbstractMetricParams{T}, u, v) where {T}
+@inline function redshift_function(m::BoyerLindquistAD, u, v)
     isco = Gradus.isco(m)
     if u[2] > isco
         regular_pdotu_inv(m, u, v)
@@ -226,7 +241,7 @@ function _redshift_guard(
 ) where {T}
     RedshiftFunctions.redshift_function(m, gp.u2, gp.p, gp.t2)
 end
-function _redshift_guard(m::AbstractMetricParams{T}, gp, max_time) where {T}
+function _redshift_guard(m::AbstractMetricParams, gp, max_time)
     RedshiftFunctions.redshift_function(m, gp.u2, gp.v2)
 end
 
@@ -269,7 +284,8 @@ function interpolate_redshift(plunging_interpolation, u)
         end
     PointFunction(closure)
 end
-# interpolate_redshift(m::AbstractMetricParams, u) =
-#     interpolate_redshift(interpolate_plunging_velocities(m), u)
+
+interpolate_redshift(m::AbstractMetricParams, u; kwargs...) =
+    interpolate_redshift(interpolate_plunging_velocities(m; kwargs...), u)
 
 export RedshiftFunctions, interpolate_redshift

--- a/src/redshift.jl
+++ b/src/redshift.jl
@@ -1,6 +1,6 @@
 module RedshiftFunctions
 import ..Gradus
-import ..Gradus: __BoyerLindquistFO, AbstractMetricParams, KerrSpacetime, metric
+import ..Gradus: __BoyerLindquistFO, AbstractMetricParams, KerrMetric, metric
 using StaticArrays
 using Tullio: @tullio
 
@@ -168,7 +168,7 @@ uᵗ(M, rms, r, a) = γₑ(M, rms) * (1 + 2 * M * (1 + H(M, rms, r, a)) / r)
 regular_pdotu_inv(L, M, r, a, θ) =
     (eⱽ(M, r, a, θ) * √(1 - Vₑ(M, r, a, θ)^2)) / (1 - L * Ωₑ(M, r, a))
 
-@inline function regular_pdotu_inv(m::KerrSpacetime, u, v)
+@inline function regular_pdotu_inv(m::KerrMetric, u, v)
     metric_matrix = metric(m, u)
 
     # TODO: this only works for Kerr
@@ -189,7 +189,7 @@ function plunging_p_dot_u(E, a, M, L, Q, rms, r, sign_r)
     )
 end
 
-function plunging_p_dot_u(m::KerrSpacetime, u, v, rms)
+function plunging_p_dot_u(m::KerrMetric, u, v, rms)
     metric_matrix = metric(m, u)
 
     # reverse signs of the velocity vector
@@ -222,7 +222,7 @@ end
     end
 end
 
-@inline function redshift_function(m::KerrSpacetime, u, v)
+@inline function redshift_function(m::KerrMetric, u, v)
     isco = Gradus.isco(m)
     if u[2] > isco
         regular_pdotu_inv(m, u, v)

--- a/src/redshift.jl
+++ b/src/redshift.jl
@@ -1,6 +1,6 @@
 module RedshiftFunctions
 import ..Gradus
-import ..Gradus: __BoyerLindquistFO, AbstractMetricParams, BoyerLindquistAD, metric
+import ..Gradus: __BoyerLindquistFO, AbstractMetricParams, KerrSpacetime, metric
 using StaticArrays
 using Tullio: @tullio
 
@@ -168,7 +168,7 @@ uᵗ(M, rms, r, a) = γₑ(M, rms) * (1 + 2 * M * (1 + H(M, rms, r, a)) / r)
 regular_pdotu_inv(L, M, r, a, θ) =
     (eⱽ(M, r, a, θ) * √(1 - Vₑ(M, r, a, θ)^2)) / (1 - L * Ωₑ(M, r, a))
 
-@inline function regular_pdotu_inv(m::BoyerLindquistAD, u, v)
+@inline function regular_pdotu_inv(m::KerrSpacetime, u, v)
     metric_matrix = metric(m, u)
 
     # TODO: this only works for Kerr
@@ -189,7 +189,7 @@ function plunging_p_dot_u(E, a, M, L, Q, rms, r, sign_r)
     )
 end
 
-function plunging_p_dot_u(m::BoyerLindquistAD, u, v, rms)
+function plunging_p_dot_u(m::KerrSpacetime, u, v, rms)
     metric_matrix = metric(m, u)
 
     # reverse signs of the velocity vector
@@ -207,7 +207,7 @@ function plunging_p_dot_u(m::BoyerLindquistAD, u, v, rms)
     1 / g
 end
 
-@inline function redshift_function(m::Gradus.BoyerLindquistFO, u, p, λ)
+@inline function redshift_function(m::Gradus.KerrSpacetimeFirstOrder, u, p, λ)
     isco = Gradus.isco(m)
     if u[2] > isco
         @inbounds regular_pdotu_inv(p.L, m.M, u[2], m.a, u[3])
@@ -222,7 +222,7 @@ end
     end
 end
 
-@inline function redshift_function(m::BoyerLindquistAD, u, v)
+@inline function redshift_function(m::KerrSpacetime, u, v)
     isco = Gradus.isco(m)
     if u[2] > isco
         regular_pdotu_inv(m, u, v)
@@ -235,7 +235,7 @@ end # module
 
 # point functions exports
 function _redshift_guard(
-    m::Gradus.BoyerLindquistFO{T},
+    m::Gradus.KerrSpacetimeFirstOrder{T},
     gp::FirstOrderGeodesicPoint{T},
     max_time,
 ) where {T}

--- a/src/rendering/rendering.jl
+++ b/src/rendering/rendering.jl
@@ -25,7 +25,7 @@ function rendergeodesics(
 end
 
 function prerendergeodesics(
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     init_pos,
     max_time;
     cache = EndpointCache(),
@@ -33,7 +33,7 @@ function prerendergeodesics(
     image_height = 250,
     fov_factor = 3.0,
     kwargs...,
-) where {T}
+)
     __prerendergeodesics(
         m,
         init_pos,
@@ -48,41 +48,41 @@ end
 
 function render_into_image!(
     image,
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     init_pos,
     max_time;
     pf,
     kwargs...,
-) where {T}
+)
     simsols = __render_geodesics(m, init_pos, max_time, ; kwargs...)
     apply_to_image!(m, image, simsols, pf, max_time)
     image
 end
 
-function apply_to_image!(m::AbstractMetricParams{T}, image, sols, pf, max_time) where {T}
+function apply_to_image!(m::AbstractMetricParams, image, sols, pf, max_time)
     @inbounds @threads for i = 1:length(sols)
         image[i] = pf(m, getgeodesicpoint(m, sols[i]), max_time)
     end
 end
 
 function __prerendergeodesics(
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     init_pos,
     cache::AbstractRenderCache;
     kwargs...,
-) where {T}
+)
     error("Not implemented for render cache strategy '$typeof(cache)'.")
 end
 
 function __prerendergeodesics(
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     init_pos,
     max_time,
     cache::SolutionCache;
     image_height,
     image_width,
     kwargs...,
-) where {T}
+)
     simsols = __render_geodesics(
         m,
         init_pos,
@@ -95,14 +95,14 @@ function __prerendergeodesics(
 end
 
 function __prerendergeodesics(
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     init_pos,
     max_time,
     cache::EndpointCache;
     image_height,
     image_width,
     kwargs...,
-) where {T}
+)
     simsols = __render_geodesics(
         m,
         init_pos,
@@ -125,7 +125,7 @@ end
 
 function __render_geodesics(
     m::AbstractMetricParams{T},
-    init_pos,
+    init_pos::AbstractVector{T},
     max_time;
     image_width,
     image_height,

--- a/src/rendering/rendering.jl
+++ b/src/rendering/rendering.jl
@@ -61,7 +61,7 @@ end
 
 function apply_to_image!(m::AbstractMetricParams, image, sols, pf, max_time)
     @inbounds @threads for i = 1:length(sols)
-        image[i] = pf(m, getgeodesicpoint(m, sols[i]), max_time)
+        image[i] = pf(m, process_solution(m, sols[i]), max_time)
     end
 end
 
@@ -112,7 +112,7 @@ function __prerendergeodesics(
         kwargs...,
     )
 
-    point_cache = map(sol -> getgeodesicpoint(m, sol), simsols)
+    point_cache = map(sol -> process_solution(m, sol), simsols)
 
     EndpointRenderCache(
         m,

--- a/src/rendering/utility.jl
+++ b/src/rendering/utility.jl
@@ -8,21 +8,11 @@ Calculates initial four-velocity vectors from impact parameters ``\\alpha`` and
 respectively, whereas ``\\beta`` is a single ``T`` value, such that a variety of geodesics
 in the same plane may be easily traced.
 """
-function calculate_velocities(
-    m::AbstractMetricParams{T},
-    init_pos,
-    α_generator,
-    β::T,
-) where {T}
+function calculate_velocities(m::AbstractMetricParams, init_pos, α_generator, β::Number)
     [map_impact_parameters(m, init_pos, α, β) for α in α_generator]
 end
 
-function calculate_velocities(
-    m::AbstractMetricParams{T},
-    init_pos,
-    α_genetator,
-    β_generator,
-) where {T}
+function calculate_velocities(m::AbstractMetricParams, init_pos, α_genetator, β_generator)
     [map_impact_parameters(m, init_pos, α, β) for α in α_genetator, β in β_generator]
 end
 
@@ -31,11 +21,11 @@ In-place specialisation, writing the four-velocities into `vs`.
 """
 function calculate_velocities!(
     vs,
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     init_pos,
     α_generator,
-    β::T,
-) where {T}
+    β::Number,
+)
     for (i, α) in enumerate(α_generator)
         vs[i] = map_impact_parameters(m, init_pos, α, β)
     end
@@ -58,7 +48,6 @@ Utility function for converting some `Y` on an image plane into ``\\beta``, give
 the midpoint `y_mid` and field-of-view multiplier `fov_factor`.
 """
 y_to_β(Y, y_mid, fov_factor) = (Y - y_mid) / fov_factor
-
 
 function init_progress_bar(text, N, enabled)
     ProgressMeter.Progress(

--- a/src/special-radii.jl
+++ b/src/special-radii.jl
@@ -6,20 +6,19 @@ Innermost stable circular orbit (ISCO), defined by
     \\frac{\\text{d}}{\\text{d}r} \\left( \\frac{E}{\\mu} \\right) = 0.
 ```
 Uses analytic solutions if known for that metric, else uses a root finder to calculate
-the radius at which the defining condition is met.
+the radius at which the above condition is met.
 """
-isco(m::AbstractMetricParams{T}) where {T} = error("Not implemented for $(typeof(m)).")
+isco(m::AbstractMetricParams) = error("Not implemented for $(typeof(m)).")
 
-function isco(
-    m::AbstractAutoDiffStaticAxisSymmetricParams{T},
-    lower_bound,
-    upper_bound,
-) where {T}
+function isco(m::AbstractAutoDiffStaticAxisSymmetricParams, lower_bound, upper_bound)
     dE(r) = ForwardDiff.derivative(x -> CircularOrbits.energy(m, x), r)
     d2E(r) = ForwardDiff.derivative(dE, r)
 
     Roots.find_zero((dE, d2E), (lower_bound, upper_bound))
 end
+
+isco(m::AbstractAutoDiffStaticAxisSymmetricParams) =
+    isco(m, find_lower_isco_bound(m), 100.0)
 
 """
     $(TYPEDSIGNATURES)
@@ -45,9 +44,6 @@ function find_lower_isco_bound(
     return T(0.0)
 end
 
-isco(m::AbstractAutoDiffStaticAxisSymmetricParams{T}) where {T} =
-    isco(m, find_lower_isco_bound(m), 100.0)
-
 """
     $(TYPEDSIGNATURES)
 
@@ -56,7 +52,7 @@ Photon orbit radius, defined as the radius for which
     \\frac{E}{\\mu} \\rightarrow \\infty .
 ```
 """
-r_ph(m::AbstractMetricParams{T}) where {T} = error("Not implemented for $(typeof(m)).")
+photon_orbit(m::AbstractMetricParams) = error("Not implemented for $(typeof(m)).")
 
 """
     $(TYPEDSIGNATURES)
@@ -66,18 +62,13 @@ Marginally bound orbit
     \\frac{E}{\\mu} = 1.
 ```
 """
-r_mb(m::AbstractMetricParams{T}) where {T} = error("Not implemented for $(typeof(m)).")
+marginally_bound_orbit(m::AbstractMetricParams) = error("Not implemented for $(typeof(m)).")
 
 """
-    $(TYPEDSIGNATURES)
+    event_horizon(m::AbstractMetricParams; select = last, resolution = 100, θε = 1e-7, rmax = 5.0)
 
 Event horizon radius, often equivalent to [`GradusBase.inner_radius`](@ref), however remains
 distinct, such that the latter may still be an arbitrary chart cutoff.
-"""
-r_s(m::AbstractMetricParams{T}) where {T} = error("Not implemented for $(typeof(m)).")
-
-"""
-    eventhorizon(m::AbstractMetricParams; select = last, resolution = 100, θε = 1e-7, rmax = 5.0)
 
 Utility function for helping plot an event horizon shape. Returns a tuple containing the `r`
 and `θ` vectors that solve
@@ -92,7 +83,7 @@ that the metric describes a naked singularity.
 Often the equation will have multiple roots, in which case the keyword argument `select` may be
 assigned to select the desired root.
 """
-eventhorizon(m::AbstractMetricParams{T}; kwargs...) where {T} =
+event_horizon(m::AbstractMetricParams; kwargs...) =
     error("Not implemented for $(typeof(m)).")
 
 function _event_horizon_condition(m, r, θ)
@@ -100,7 +91,7 @@ function _event_horizon_condition(m, r, θ)
     g[5]^2 - g[1] * g[4]
 end
 
-function eventhorizon(
+function event_horizon(
     m::AbstractAutoDiffStaticAxisSymmetricParams{T};
     select = maximum,
     resolution::Int = 100,
@@ -132,4 +123,4 @@ function is_naked_singularity(
     end
 end
 
-export eventhorizon, is_naked_singularity
+export event_horizon, is_naked_singularity

--- a/src/tracing/callbacks.jl
+++ b/src/tracing/callbacks.jl
@@ -37,11 +37,12 @@ function create_callback_set(
     mcb = metric_callback(m, closest_approach, effective_infinity)
     if C <: SciMLBase.DECallback
         mcb isa Tuple ? CallbackSet(cb, mcb...) : CallbackSet(cb, mcb)
-    elseif C <: Union{Tuple,AbstractVector}
+    elseif C <: Tuple
         mcb isa Tuple ? CallbackSet(cb..., mcb...) : CallbackSet(cb..., mcb)
-    else
-        # else C is Nothing
+    elseif C <: Nothing
         mcb isa Tuple ? CallbackSet(mcb...) : mcb
+    else
+        error("Unknown callback type $C")
     end
 end
 

--- a/src/tracing/constraints.jl
+++ b/src/tracing/constraints.jl
@@ -1,5 +1,5 @@
 # vectors of vectors 
-function constrain_all(m::AbstractMetricParams{T}, us, vs, μ) where {T}
+function constrain_all(m::AbstractMetricParams, us, vs, μ)
     @inbounds for i in eachindex(vs)
         vs[i] = constrain_all(m, us[i], vs[i], μ)
     end
@@ -31,11 +31,6 @@ function constrain_all(
     @inbounds SVector{S,T}(constrain(m, u, v, μ = μ), v[2], v[3], v[4])
 end
 
-function wrap_constraint(
-    m::AbstractMetricParams{T},
-    position,
-    velfunc::Function,
-    μ,
-) where {T}
+function wrap_constraint(m::AbstractMetricParams, position, velfunc::Function, μ)
     (i) -> constrain_all(m, position, velfunc(i), μ)
 end

--- a/src/tracing/method-implementations/auto-diff.jl
+++ b/src/tracing/method-implementations/auto-diff.jl
@@ -41,7 +41,7 @@ a vector or tuple with the elements
 \\right).
 ```
 """
-metric_components(m::AbstractAutoDiffStaticAxisSymmetricParams{T}, rθ) where {T} =
+metric_components(m::AbstractAutoDiffStaticAxisSymmetricParams, rθ) =
     error("Not implemented for $(typeof(m)).")
 
 """
@@ -233,7 +233,7 @@ function constrain(
     m::AbstractAutoDiffStaticAxisSymmetricParams{T},
     u,
     v;
-    μ::T = 0.0,
+    μ::T = T(0.0),
 ) where {T}
     rθ = (u[2], u[3])
     g_comps = metric_components(m, rθ)
@@ -281,7 +281,7 @@ end
 end
 
 
-function metric(m::AbstractAutoDiffStaticAxisSymmetricParams{T}, u) where {T}
+function metric(m::AbstractAutoDiffStaticAxisSymmetricParams, u)
     rθ = (u[2], u[3])
     comps = metric_components(m, rθ)
     @SMatrix [

--- a/src/tracing/method-implementations/first-order.jl
+++ b/src/tracing/method-implementations/first-order.jl
@@ -34,7 +34,7 @@ abstract type AbstractFirstOrderMetricParams{T} <: AbstractMetricParams{T} end
     p::P
 end
 
-@inbounds function getgeodesicpoint(
+@inbounds function process_solution(
     m::AbstractFirstOrderMetricParams{T},
     sol::SciMLBase.AbstractODESolution{T},
 ) where {T}

--- a/src/tracing/tracing.jl
+++ b/src/tracing/tracing.jl
@@ -3,7 +3,7 @@
         m::AbstractMetricParams{T},
         position,
         velocity,
-        time_domain::Tuple{T,T};
+        time_domain::NTuple{2};
         solver = Tsit5(),
         μ = 0.0,
         closest_approach = 1.01,
@@ -29,7 +29,7 @@ function tracegeodesics(
     m::AbstractMetricParams{T},
     position,
     velocity,
-    time_domain::Tuple{T,T};
+    time_domain::NTuple{2};
     solver = Tsit5(),
     μ = 0.0,
     closest_approach = 1.01,
@@ -106,7 +106,7 @@ function __tracegeodesics(
     m::AbstractMetricParams{T},
     init_pos::AbstractVector{T},
     init_vel::AbstractVector{T},
-    time_domain::Tuple{T,T},
+    time_domain::NTuple{2},
     solver;
     kwargs...,
 ) where {T<:Number}
@@ -120,7 +120,7 @@ function __tracegeodesics(
     m::AbstractMetricParams{T},
     init_pos::AbstractVector{T},
     vel_func::Function,
-    time_domain::Tuple{T,T},
+    time_domain::NTuple{2},
     solver;
     trajectories::Int,
     ensemble = EnsembleThreads(),
@@ -141,7 +141,7 @@ function __tracegeodesics(
     m::AbstractMetricParams{T},
     init_positions,
     init_velocities,
-    time_domain::Tuple{T,T},
+    time_domain::NTuple{2},
     solver;
     ensemble = EnsembleThreads(),
     kwargs...,
@@ -163,12 +163,12 @@ function __tracegeodesics(
     )
 end
 
-function solve_geodesic(solver, prob, ensemble; solver_opts...)
+# ensemble dispatch
+solve_geodesic(solver, prob, ensemble; solver_opts...) =
     solve(prob, solver, ensemble; solver_opts..., kwargshandle = KeywordArgError)
-end
 
-function solve_geodesic(solver, prob; solver_opts...)
+# non-ensemble dispatch
+solve_geodesic(solver, prob; solver_opts...) =
     solve(prob, solver, ; solver_opts..., kwargshandle = KeywordArgError)
-end
 
 export tracegeodesics

--- a/src/tracing/utility.jl
+++ b/src/tracing/utility.jl
@@ -9,7 +9,7 @@ function map_impact_parameters(
     α::N,
     β::N,
 ) where {T,N<:Number}
-    [0.0, impact_parameters_to_vel(m, u, α, β)...]
+    [T(0.0), impact_parameters_to_vel(m, u, α, β)...]
 end
 
 function map_impact_parameters(
@@ -18,7 +18,7 @@ function map_impact_parameters(
     α::N,
     β::N,
 ) where {S,T,N<:Number}
-    SVector{S,T}(0.0, impact_parameters_to_vel(m, u, α, β)...)
+    SVector{S,T}(T(0.0), impact_parameters_to_vel(m, u, α, β)...)
 end
 
 function map_impact_parameters(
@@ -33,7 +33,7 @@ end
 
 function impact_parameters_to_vel(m::AbstractMetricParams{T}, u, α, β) where {T}
     mcomp = metric_components(m, @view(u[2:3]))
-    -1.0, -β / mcomp[3], -α / √(mcomp[3] * mcomp[4])
+    T(-1.0), -β / mcomp[3], -α / √(mcomp[3] * mcomp[4])
 end
 
 export map_impact_parameters, impact_parameters_to_vel

--- a/src/transfer-functions/cunningham-transfer-functions.jl
+++ b/src/transfer-functions/cunningham-transfer-functions.jl
@@ -76,7 +76,7 @@ function cunningham_transfer_function(
     rₑ;
     max_time = 2e3,
     diff_order = 4,
-    redshift_pf = ConstPointFunctions.redshift,
+    redshift_pf = ConstPointFunctions.redshift(m, u),
     offset_max = 20.0,
     zero_atol = 1e-7,
     N = 80,

--- a/src/transfer-functions/precision-solvers.jl
+++ b/src/transfer-functions/precision-solvers.jl
@@ -162,7 +162,7 @@ function jacobian_∂αβ_∂gr(
     β,
     max_time;
     diff_order = 5,
-    redshift_pf = ConstPointFunctions.redshift,
+    redshift_pf = ConstPointFunctions.redshift(m, u),
     kwargs...,
 )
     # map impact parameters to r, g

--- a/src/transfer-functions/precision-solvers.jl
+++ b/src/transfer-functions/precision-solvers.jl
@@ -25,7 +25,7 @@ function integrate_single_geodesic(
     β = rₒ * sin(θₒ)
     v = map_impact_parameters(m, u, α, β)
     sol = tracegeodesics(m, u, v, d, (0.0, max_time); save_on = false, kwargs...)
-    getgeodesicpoint(m, sol)
+    process_solution(m, sol)
 end
 
 """
@@ -171,7 +171,7 @@ function jacobian_∂αβ_∂gr(
             v = map_impact_parameters(m, u, α, β)
             sol =
                 tracegeodesics(m, u, v, d, (0.0, max_time); save_on = false, kwargs...)
-            gp = getgeodesicpoint(m, sol)
+            gp = process_solution(m, sol)
             g = redshift_pf(m, gp, 2000.0)
             # return r and g*
             @SVector [gp.u2[2], g]

--- a/test/image-planes/test-cartesian-grids.jl
+++ b/test/image-planes/test-cartesian-grids.jl
@@ -4,7 +4,7 @@ using StaticArrays
 
 include("../utils.jl")
 
-m = BoyerLindquistAD()
+m = KerrSpacetime()
 u = @SVector [1.0, 1e3, π / 2, 0.0]
 
 # check the trace bootstrap works for each grid type

--- a/test/image-planes/test-cartesian-grids.jl
+++ b/test/image-planes/test-cartesian-grids.jl
@@ -4,7 +4,7 @@ using StaticArrays
 
 include("../utils.jl")
 
-m = KerrSpacetime()
+m = KerrMetric()
 u = @SVector [1.0, 1e3, π / 2, 0.0]
 
 # check the trace bootstrap works for each grid type

--- a/test/image-planes/test-polar-grids.jl
+++ b/test/image-planes/test-polar-grids.jl
@@ -4,7 +4,7 @@ using StaticArrays
 
 include("../utils.jl")
 
-m = BoyerLindquistAD()
+m = KerrSpacetime()
 u = @SVector [1.0, 1e3, π / 2, 0.0]
 
 # check the trace bootstrap works for each grid type

--- a/test/image-planes/test-polar-grids.jl
+++ b/test/image-planes/test-polar-grids.jl
@@ -4,7 +4,7 @@ using StaticArrays
 
 include("../utils.jl")
 
-m = KerrSpacetime()
+m = KerrMetric()
 u = @SVector [1.0, 1e3, π / 2, 0.0]
 
 # check the trace bootstrap works for each grid type

--- a/test/integration/test-inference.jl
+++ b/test/integration/test-inference.jl
@@ -1,0 +1,38 @@
+using Test
+using Gradus
+using StaticArrays
+
+m = BoyerLindquistAD()
+u = @SVector [0.0, 1e3, π / 2, 0.0]
+v = @SVector [0.0, 1.0, 0.0, 0.0]
+
+# single vector for u and v
+info = code_typed(tracegeodesics, (typeof(m), typeof(u), typeof(v), Tuple{Float64,Float64}))
+info = first(info)
+@test isconcretetype(info.second)
+
+# multiple vectors for u and v
+u = [u, u]
+v = [v, v]
+info = code_typed(tracegeodesics, (typeof(m), typeof(u), typeof(v), Tuple{Float64,Float64}))
+info = first(info)
+@test isconcretetype(info.second)
+
+# v is a velocity function
+u = @SVector [0.0, 1e3, π / 2, 0.0]
+vfunc = (i) -> @SVector [0.0, 1.0, 0.0, 0.0]
+info = code_typed(
+    (args...) -> tracegeodesics(args...; trajectories = 10),
+    (typeof(m), typeof(u), typeof(vfunc), Tuple{Float64,Float64}),
+)
+info = first(info)
+@test isconcretetype(info.second)
+
+# v is a plane
+plane = PolarPlane(LinearGrid())
+info = code_typed(
+    tracegeodesics,
+    (typeof(m), typeof(u), typeof(plane), Tuple{Float64,Float64}),
+)
+info = first(info)
+@test isconcretetype(info.second)

--- a/test/integration/test-inference.jl
+++ b/test/integration/test-inference.jl
@@ -2,7 +2,7 @@ using Test
 using Gradus
 using StaticArrays
 
-m = KerrSpacetime()
+m = KerrMetric()
 u = @SVector [0.0, 1e3, π / 2, 0.0]
 v = @SVector [0.0, 1.0, 0.0, 0.0]
 

--- a/test/integration/test-inference.jl
+++ b/test/integration/test-inference.jl
@@ -2,7 +2,7 @@ using Test
 using Gradus
 using StaticArrays
 
-m = BoyerLindquistAD()
+m = KerrSpacetime()
 u = @SVector [0.0, 1e3, π / 2, 0.0]
 v = @SVector [0.0, 1.0, 0.0, 0.0]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ end
 
 @testset "metric-geometry" verbose = true begin
     include("unit/gradusbase.geometry.jl")
+    include("test-special-radii.jl")
 end
 
 @testset "image-planes" verbose = true begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,10 @@ end
     include("test-special-radii.jl")
 end
 
+@testset "integration" verbose = true begin
+    include("integration/test-inference.jl")
+end
+
 @testset "image-planes" verbose = true begin
     include("image-planes/test-polar-grids.jl")
     include("image-planes/test-cartesian-grids.jl")

--- a/test/smoke-tests/circular-orbits.jl
+++ b/test/smoke-tests/circular-orbits.jl
@@ -12,10 +12,10 @@ using StaticArrays
         # last updated: 22 Apr 2022
         r_range = 6.0:0.5:10.0
         for (m, expected) in [
-            (BoyerLindquistAD(M = 1.0, a = 0.0), 0.5432533297869712),
-            (BoyerLindquistAD(M = 1.0, a = 1.0), 0.5016710246454921),
-            (BoyerLindquistAD(M = 1.0, a = -1.0), 0.5993458160081419),
-            (JohannsenAD(M = 1.0, a = 1.0, α22 = 1.0), 0.4980454719932759),
+            (KerrSpacetime(M = 1.0, a = 0.0), 0.5432533297869712),
+            (KerrSpacetime(M = 1.0, a = 1.0), 0.5016710246454921),
+            (KerrSpacetime(M = 1.0, a = -1.0), 0.5993458160081419),
+            (JohannsenMetric(M = 1.0, a = 1.0, α22 = 1.0), 0.4980454719932759),
         ]
             vϕs = solve_equitorial_circular_orbit(m, r_range)
             @test isapprox(sum(vϕs), expected, atol = 1e-6, rtol = 0.0)
@@ -23,7 +23,7 @@ using StaticArrays
     end
 
     @testset "trace_equitorial_circular_orbit" begin
-        m = BoyerLindquistAD(M = 1.0, a = 0.0)
+        m = KerrSpacetime(M = 1.0, a = 0.0)
         Gradus.isco(m)
         r_range = 6.0:0.1:10.0
         simsols = trace_equitorial_circular_orbit(m, r_range)

--- a/test/smoke-tests/circular-orbits.jl
+++ b/test/smoke-tests/circular-orbits.jl
@@ -12,9 +12,9 @@ using StaticArrays
         # last updated: 22 Apr 2022
         r_range = 6.0:0.5:10.0
         for (m, expected) in [
-            (KerrSpacetime(M = 1.0, a = 0.0), 0.5432533297869712),
-            (KerrSpacetime(M = 1.0, a = 1.0), 0.5016710246454921),
-            (KerrSpacetime(M = 1.0, a = -1.0), 0.5993458160081419),
+            (KerrMetric(M = 1.0, a = 0.0), 0.5432533297869712),
+            (KerrMetric(M = 1.0, a = 1.0), 0.5016710246454921),
+            (KerrMetric(M = 1.0, a = -1.0), 0.5993458160081419),
             (JohannsenMetric(M = 1.0, a = 1.0, α22 = 1.0), 0.4980454719932759),
         ]
             vϕs = solve_equitorial_circular_orbit(m, r_range)
@@ -23,7 +23,7 @@ using StaticArrays
     end
 
     @testset "trace_equitorial_circular_orbit" begin
-        m = KerrSpacetime(M = 1.0, a = 0.0)
+        m = KerrMetric(M = 1.0, a = 0.0)
         Gradus.isco(m)
         r_range = 6.0:0.1:10.0
         simsols = trace_equitorial_circular_orbit(m, r_range)

--- a/test/smoke-tests/cunningham-transfer-functions.jl
+++ b/test/smoke-tests/cunningham-transfer-functions.jl
@@ -3,7 +3,7 @@ using Gradus
 using StaticArrays
 
 @testset "cunningham-transfer-functions" begin
-    m = KerrSpacetime(1.0, 0.998)
+    m = KerrMetric(1.0, 0.998)
     d = GeometricThinDisc(0.0, 400.0, deg2rad(90))
 
     # test for different angles

--- a/test/smoke-tests/cunningham-transfer-functions.jl
+++ b/test/smoke-tests/cunningham-transfer-functions.jl
@@ -3,7 +3,7 @@ using Gradus
 using StaticArrays
 
 @testset "cunningham-transfer-functions" begin
-    m = BoyerLindquistAD(1.0, 0.998)
+    m = KerrSpacetime(1.0, 0.998)
     d = GeometricThinDisc(0.0, 400.0, deg2rad(90))
 
     # test for different angles

--- a/test/smoke-tests/disc-profiles.jl
+++ b/test/smoke-tests/disc-profiles.jl
@@ -7,7 +7,7 @@ using StaticArrays
 @testset "disc-profiles" begin
 
     @testset "voronoi-tesselation" begin
-        m = BoyerLindquistAD(M = 1.0, a = 1.0)
+        m = KerrSpacetime(M = 1.0, a = 1.0)
         d = GeometricThinDisc(1.0, 40.0, deg2rad(90.0))
         model = LampPostModel(h = 10.0, θ = deg2rad(0.0001))
         simsols = tracegeodesics(

--- a/test/smoke-tests/disc-profiles.jl
+++ b/test/smoke-tests/disc-profiles.jl
@@ -21,7 +21,7 @@ using StaticArrays
 
         intersected_simsols =
             filter(i -> i.prob.p.status == StatusCodes.IntersectedWithGeometry, simsols.u)
-        sd_endpoints = map(sol -> getgeodesicpoint(m, sol), intersected_simsols)
+        sd_endpoints = map(sol -> process_solution(m, sol), intersected_simsols)
 
         # test ensemble solution constructor
         vdp1 = VoronoiDiscProfile(m, d, simsols)

--- a/test/smoke-tests/disc-profiles.jl
+++ b/test/smoke-tests/disc-profiles.jl
@@ -7,7 +7,7 @@ using StaticArrays
 @testset "disc-profiles" begin
 
     @testset "voronoi-tesselation" begin
-        m = KerrSpacetime(M = 1.0, a = 1.0)
+        m = KerrMetric(M = 1.0, a = 1.0)
         d = GeometricThinDisc(1.0, 40.0, deg2rad(90.0))
         model = LampPostModel(h = 10.0, θ = deg2rad(0.0001))
         simsols = tracegeodesics(

--- a/test/smoke-tests/line-profiles.jl
+++ b/test/smoke-tests/line-profiles.jl
@@ -5,7 +5,7 @@ using StaticArrays
 @testset "line-profiles" begin
     d = GeometricThinDisc(0.0, 300.0, π / 2)
     u = @SVector [0.0, 1000.0, deg2rad(40), 0.0]
-    m = BoyerLindquistAD(M = 1.0, a = 0.998)
+    m = KerrSpacetime(M = 1.0, a = 0.998)
 
     @testset "cunningham" begin
         x = range(0.1, 1.2, 20)

--- a/test/smoke-tests/line-profiles.jl
+++ b/test/smoke-tests/line-profiles.jl
@@ -5,7 +5,7 @@ using StaticArrays
 @testset "line-profiles" begin
     d = GeometricThinDisc(0.0, 300.0, π / 2)
     u = @SVector [0.0, 1000.0, deg2rad(40), 0.0]
-    m = KerrSpacetime(M = 1.0, a = 0.998)
+    m = KerrMetric(M = 1.0, a = 0.998)
 
     @testset "cunningham" begin
         x = range(0.1, 1.2, 20)

--- a/test/smoke-tests/pointfunctions.jl
+++ b/test/smoke-tests/pointfunctions.jl
@@ -25,7 +25,7 @@ using StaticArrays
 
     @testset "redshift" begin
         # only implemented for the BoyerLindquist metrics at the moment
-        for m in [KerrSpacetime(), KerrSpacetimeFirstOrder()]
+        for m in [KerrMetric(), KerrSpacetimeFirstOrder()]
             run_pointfunction(m, Gradus.ConstPointFunctions.redshift(m, u))
         end
         # smoke test passed

--- a/test/smoke-tests/pointfunctions.jl
+++ b/test/smoke-tests/pointfunctions.jl
@@ -25,7 +25,7 @@ using StaticArrays
 
     @testset "redshift" begin
         # only implemented for the BoyerLindquist metrics at the moment
-        for m in [BoyerLindquistAD(), BoyerLindquistFO()]
+        for m in [KerrSpacetime(), KerrSpacetimeFirstOrder()]
             run_pointfunction(m, Gradus.ConstPointFunctions.redshift(m, u))
         end
         # smoke test passed

--- a/test/smoke-tests/pointfunctions.jl
+++ b/test/smoke-tests/pointfunctions.jl
@@ -5,9 +5,9 @@ using StaticArrays
 # Tests to make sure the basic pointfunctions work
 
 @testset "pointfunctions" begin
+    u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
 
     function run_pointfunction(m, pf)
-        u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
         d = GeometricThinDisc(10.0, 40.0, deg2rad(90.0))
         img = rendergeodesics(
             m,
@@ -20,12 +20,13 @@ using StaticArrays
             pf = pf,
             verbose = false,
         )
+        img
     end
 
     @testset "redshift" begin
         # only implemented for the BoyerLindquist metrics at the moment
         for m in [BoyerLindquistAD(), BoyerLindquistFO()]
-            run_pointfunction(m, Gradus.ConstPointFunctions.redshift)
+            run_pointfunction(m, Gradus.ConstPointFunctions.redshift(m, u))
         end
         # smoke test passed
         @test true

--- a/test/smoke-tests/rendergeodesics.jl
+++ b/test/smoke-tests/rendergeodesics.jl
@@ -19,7 +19,7 @@ end
     @testset "plain" begin
         u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
         for (m, expectation) in zip(
-            [BoyerLindquistAD(), JohannsenAD(), BoyerLindquistFO(), MorrisThorneAD()],
+            [KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole()],
             # expectation values for the sum of the image
             # last computed 04/06/2022: tests with --math-mode=ieee
             [8969.1564582409967, 8969.15634220181, 8977.502920124776, 413.49634341337264],
@@ -44,7 +44,7 @@ end
         u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
         d = GeometricThinDisc(10.0, 40.0, deg2rad(90.0))
         for (m, expectation) in zip(
-            [BoyerLindquistAD(), JohannsenAD(), BoyerLindquistFO(), MorrisThorneAD()],
+            [KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole()],
             # expectation values for the sum of the image
             # last computed 15/11/2022: continuous callback for disc intersection
             [90696.01318073242, 90491.9434460566, 86277.8210033628, 39094.80412600604],
@@ -68,7 +68,7 @@ end
     @testset "shakura-sunyaev-disc" begin
         u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
         for (m, expectation) in zip(
-            [BoyerLindquistAD(), JohannsenAD()],
+            [KerrSpacetime(), JohannsenMetric()],
             # expectation values for the sum of the image
             # last computed 11/10/2022: initial values
             [282541.415414396, 282541.4154167309],
@@ -93,7 +93,7 @@ end
         u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
         d = ThickDisc(_thick_disc)
         for (m, expectation) in zip(
-            [BoyerLindquistAD(), JohannsenAD(), BoyerLindquistFO(), MorrisThorneAD()],
+            [KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole()],
             # expectation values for the sum of the image
             # last computed 11/10/2022: initial values
             [17755.784049024965, 17755.7836819751439, 18018.50638877236, 5401.369964242934],

--- a/test/smoke-tests/rendergeodesics.jl
+++ b/test/smoke-tests/rendergeodesics.jl
@@ -14,103 +14,100 @@ function _thick_disc(u)
     end
 end
 
-@testset "rendergeodesics" begin
+@testset "plain" begin
+    u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
 
-    @testset "plain" begin
-        u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
-        for (m, expectation) in zip(
-            [KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole()],
-            # expectation values for the sum of the image
-            # last computed 04/06/2022: tests with --math-mode=ieee
-            [8969.1564582409967, 8969.15634220181, 8977.502920124776, 413.49634341337264],
+    # last computed 21/01/2023: shrink resolution
+    expected = (8969.1564582409967, 8969.15634220181, 8977.502920124776, 413.4963434133726)
+    result = map((KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole())) do m
+        img = rendergeodesics(
+            m,
+            u,
+            200.0,
+            fov_factor = 1.0,
+            image_width = 20,
+            image_height = 20,
+            verbose = false,
         )
-            img = rendergeodesics(
-                m,
-                u,
-                200.0,
-                fov_factor = 1.0,
-                image_width = 100,
-                image_height = 50,
-                verbose = false,
-            )
-            image_fingerprint = sum(filter(!isnan, img))
-            # have to be really coarse cus the first order method is so variable???
-            # the rest are very resolute
-            @test isapprox(expectation, image_fingerprint; rtol = 0.1)
-        end
+        image_fingerprint = sum(filter(!isnan, img))
     end
+    for (e, v) in zip(expected, result)
+        # this tolerance is kind of unacceptably high? todo: investigate why
+        @test isapprox(e, v; rtol = 0.1)
+    end
+end
 
-    @testset "thin-disc" begin
-        u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
-        d = GeometricThinDisc(10.0, 40.0, deg2rad(90.0))
-        for (m, expectation) in zip(
-            [KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole()],
-            # expectation values for the sum of the image
-            # last computed 15/11/2022: continuous callback for disc intersection
-            [90696.01318073242, 90491.9434460566, 86277.8210033628, 39094.80412600604],
+@testset "thin-disc" begin
+    u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
+    d = GeometricThinDisc(10.0, 40.0, deg2rad(90.0))
+
+    # last computed 21/01/2023: shrink resolution
+    expected = (29605.55590761622, 29605.556409711604, 29741.80749605271, 9858.77920909911)
+    result = map((KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole())) do m
+        img = rendergeodesics(
+            m,
+            u,
+            d,
+            200.0,
+            fov_factor = 1.0,
+            image_width = 20,
+            image_height = 20,
+            verbose = false,
         )
-            img = rendergeodesics(
-                m,
-                u,
-                d,
-                200.0,
-                fov_factor = 1.0,
-                image_width = 100,
-                image_height = 50,
-                verbose = false,
-            )
-            image_fingerprint = sum(filter(!isnan, img))
-            # this tolerance is kind of unacceptably high? todo: investigate why
-            @test isapprox(expectation, image_fingerprint; rtol = 0.1)
-        end
+        image_fingerprint = sum(filter(!isnan, img))
     end
+    for (e, v) in zip(expected, result)
+        # this tolerance is kind of unacceptably high? todo: investigate why
+        @test isapprox(e, v; rtol = 0.1)
+    end
+end
 
-    @testset "shakura-sunyaev-disc" begin
-        u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
-        for (m, expectation) in zip(
-            [KerrSpacetime(), JohannsenMetric()],
-            # expectation values for the sum of the image
-            # last computed 11/10/2022: initial values
-            [282541.415414396, 282541.4154167309],
+@testset "shakura-sunyaev-disc" begin
+    u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
+
+    # last computed 21/01/2023: shrink resolution
+    expected = (34711.33445248479, 34711.33445255157)
+    result = map((KerrSpacetime(), JohannsenMetric())) do m
+        d = ShakuraSunyaev(m)
+        img = rendergeodesics(
+            m,
+            u,
+            d,
+            200.0,
+            fov_factor = 1.0,
+            image_width = 20,
+            image_height = 20,
+            verbose = false,
         )
-            d = ShakuraSunyaev(m)
-            img = rendergeodesics(
-                m,
-                u,
-                d,
-                200.0,
-                fov_factor = 1.0,
-                image_width = 100,
-                image_height = 50,
-                verbose = false,
-            )
-            image_fingerprint = sum(filter(!isnan, img))
-            @test isapprox(expectation, image_fingerprint; atol = 5.0, rtol = 0.0)
-        end
+        image_fingerprint = sum(filter(!isnan, img))
     end
+    for (e, v) in zip(expected, result)
+        # this tolerance is kind of unacceptably high? todo: investigate why
+        @test isapprox(e, v; rtol = 0.1)
+    end
+end
 
-    @testset "thick-disc" begin
-        u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
-        d = ThickDisc(_thick_disc)
-        for (m, expectation) in zip(
-            [KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole()],
-            # expectation values for the sum of the image
-            # last computed 11/10/2022: initial values
-            [17755.784049024965, 17755.7836819751439, 18018.50638877236, 5401.369964242934],
+@testset "thick-disc" begin
+    u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
+    d = ThickDisc(_thick_disc)
+
+    # last computed 21/01/2023: shrink resolution
+    expected = (16593.560393732, 16593.56001187974, 16847.84450997791, 5015.839213855068)
+    result = map((KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole())) do m
+        img = rendergeodesics(
+            m,
+            u,
+            d,
+            200.0,
+            fov_factor = 1.0,
+            image_width = 20,
+            image_height = 20,
+            verbose = false,
         )
-            img = rendergeodesics(
-                m,
-                u,
-                d,
-                200.0,
-                fov_factor = 1.0,
-                image_width = 100,
-                image_height = 50,
-                verbose = false,
-            )
-            image_fingerprint = sum(filter(!isnan, img))
-            @test isapprox(expectation, image_fingerprint; atol = 5.0, rtol = 0.0)
-        end
+        image_fingerprint = sum(filter(!isnan, img))
     end
-
+    for (e, v) in zip(expected, result)
+        # this tolerance is kind of unacceptably high? todo: investigate why
+        @test isapprox(e, v; rtol = 0.1)
+    end
 end

--- a/test/smoke-tests/rendergeodesics.jl
+++ b/test/smoke-tests/rendergeodesics.jl
@@ -19,7 +19,7 @@ end
 
     # last computed 21/01/2023: shrink resolution
     expected = (8969.1564582409967, 8969.15634220181, 8977.502920124776, 413.4963434133726)
-    result = map((KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole())) do m
+    result = map((KerrMetric(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole())) do m
         img = rendergeodesics(
             m,
             u,
@@ -43,7 +43,7 @@ end
 
     # last computed 21/01/2023: shrink resolution
     expected = (29605.55590761622, 29605.556409711604, 29741.80749605271, 9858.77920909911)
-    result = map((KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole())) do m
+    result = map((KerrMetric(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole())) do m
         img = rendergeodesics(
             m,
             u,
@@ -67,7 +67,7 @@ end
 
     # last computed 21/01/2023: shrink resolution
     expected = (34711.33445248479, 34711.33445255157)
-    result = map((KerrSpacetime(), JohannsenMetric())) do m
+    result = map((KerrMetric(), JohannsenMetric())) do m
         d = ShakuraSunyaev(m)
         img = rendergeodesics(
             m,
@@ -93,7 +93,7 @@ end
 
     # last computed 21/01/2023: shrink resolution
     expected = (16593.560393732, 16593.56001187974, 16847.84450997791, 5015.839213855068)
-    result = map((KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole())) do m
+    result = map((KerrMetric(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole())) do m
         img = rendergeodesics(
             m,
             u,

--- a/test/smoke-tests/special-radii.jl
+++ b/test/smoke-tests/special-radii.jl
@@ -8,8 +8,8 @@ using StaticArrays
     all_metrics = (
         KerrSpacetimeFirstOrder(1.0, 0.998, 1.0),
         KerrSpacetimeFirstOrder(1.0, -0.998, 1.0),
-        KerrSpacetime(1.0, 0.998),
-        KerrSpacetime(1.0, -0.998),
+        KerrMetric(1.0, 0.998),
+        KerrMetric(1.0, -0.998),
         JohannsenMetric(M = 1.0, a = 0.998, α13 = 1.0),
         JohannsenMetric(M = 1.0, a = 0.998, α22 = 1.0),
         DilatonAxion(M = 1.0, a = 0.998, β = 0.2, b = 1.0),

--- a/test/smoke-tests/special-radii.jl
+++ b/test/smoke-tests/special-radii.jl
@@ -6,13 +6,13 @@ using StaticArrays
 
 @testset "special-radii" begin
     all_metrics = (
-        BoyerLindquistFO(1.0, 0.998, 1.0),
-        BoyerLindquistFO(1.0, -0.998, 1.0),
-        BoyerLindquistAD(1.0, 0.998),
-        BoyerLindquistAD(1.0, -0.998),
-        JohannsenAD(M = 1.0, a = 0.998, α13 = 1.0),
-        JohannsenAD(M = 1.0, a = 0.998, α22 = 1.0),
-        DilatonAxionAD(M = 1.0, a = 0.998, β = 0.2, b = 1.0),
+        KerrSpacetimeFirstOrder(1.0, 0.998, 1.0),
+        KerrSpacetimeFirstOrder(1.0, -0.998, 1.0),
+        KerrSpacetime(1.0, 0.998),
+        KerrSpacetime(1.0, -0.998),
+        JohannsenMetric(M = 1.0, a = 0.998, α13 = 1.0),
+        JohannsenMetric(M = 1.0, a = 0.998, α22 = 1.0),
+        DilatonAxion(M = 1.0, a = 0.998, β = 0.2, b = 1.0),
     )
 
     @testset "iscos" begin

--- a/test/smoke-tests/tracegeodesics.jl
+++ b/test/smoke-tests/tracegeodesics.jl
@@ -25,7 +25,7 @@ using StaticArrays
         u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
         # arbitrary single velocity vector
         v = @SVector [0.0, -1.0, -0.0, -3.5e-6]
-        for m in [KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole()]
+        for m in [KerrMetric(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole()]
             test_single(m, u, v)
             test_many(m, u, v)
             # smoke test passed
@@ -37,7 +37,7 @@ using StaticArrays
         u = Float64[0.0, 100.0, deg2rad(85), 0.0]
         # arbitrary single velocity vector
         v = Float64[0.0, -1.0, -0.0, -3.5e-6]
-        for m in [KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole()]
+        for m in [KerrMetric(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole()]
             test_single(m, u, v)
             test_many(m, u, v)
             @test true
@@ -45,9 +45,9 @@ using StaticArrays
     end
 
     @testset "corona-models" begin
-        # only implemented for KerrSpacetime at the moment
+        # only implemented for KerrMetric at the moment
         # because of the vector to local sky methods
-        m = KerrSpacetime(M = 1.0, a = 0.0)
+        m = KerrMetric(M = 1.0, a = 0.0)
         d = GeometricThinDisc(Gradus.isco(m), 50.0, deg2rad(90.0))
         model = LampPostModel(h = 10.0, θ = deg2rad(0.001))
 

--- a/test/smoke-tests/tracegeodesics.jl
+++ b/test/smoke-tests/tracegeodesics.jl
@@ -25,7 +25,7 @@ using StaticArrays
         u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
         # arbitrary single velocity vector
         v = @SVector [0.0, -1.0, -0.0, -3.5e-6]
-        for m in [BoyerLindquistAD(), JohannsenAD(), BoyerLindquistFO(), MorrisThorneAD()]
+        for m in [KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole()]
             test_single(m, u, v)
             test_many(m, u, v)
             # smoke test passed
@@ -37,7 +37,7 @@ using StaticArrays
         u = Float64[0.0, 100.0, deg2rad(85), 0.0]
         # arbitrary single velocity vector
         v = Float64[0.0, -1.0, -0.0, -3.5e-6]
-        for m in [BoyerLindquistAD(), JohannsenAD(), BoyerLindquistFO(), MorrisThorneAD()]
+        for m in [KerrSpacetime(), JohannsenMetric(), KerrSpacetimeFirstOrder(), MorrisThorneWormhole()]
             test_single(m, u, v)
             test_many(m, u, v)
             @test true
@@ -45,9 +45,9 @@ using StaticArrays
     end
 
     @testset "corona-models" begin
-        # only implemented for BoyerLindquistAD at the moment
+        # only implemented for KerrSpacetime at the moment
         # because of the vector to local sky methods
-        m = BoyerLindquistAD(M = 1.0, a = 0.0)
+        m = KerrSpacetime(M = 1.0, a = 0.0)
         d = GeometricThinDisc(Gradus.isco(m), 50.0, deg2rad(90.0))
         model = LampPostModel(h = 10.0, θ = deg2rad(0.001))
 

--- a/test/test-special-radii.jl
+++ b/test/test-special-radii.jl
@@ -3,28 +3,28 @@ using Gradus
 using StaticArrays
 
 # test known radii
-m = BoyerLindquistAD(M = 1.0, a = 0.0)
+m = KerrSpacetime(M = 1.0, a = 0.0)
 @test Gradus.isco(m) == 6.0
 
-m = BoyerLindquistAD(M = 1.0, a = 1.0)
+m = KerrSpacetime(M = 1.0, a = 1.0)
 @test Gradus.isco(m) == 1.0
 
 # test event horizon code
-m = BoyerLindquistAD(M = 1.0, a = 0.0)
+m = KerrSpacetime(M = 1.0, a = 0.0)
 rs, _ = event_horizon(m)
 @test rs ≈ fill(2.0, length(rs))
 
-m = BoyerLindquistAD(M = 1.0, a = 1.0)
+m = KerrSpacetime(M = 1.0, a = 1.0)
 rs, _ = event_horizon(m)
 @test rs ≈ fill(1.0, length(rs))
 
 # make sure works for other metrics too
-for M in [JohannsenAD, JohannsenPsaltisAD]
+for M in [JohannsenMetric, JohannsenPsaltisMetric]
     @test Gradus.isco(M()) > 1.0
     _rs, _ = event_horizon(M())
     @test (_rs .> 1.0) |> all
 end
 
 # test naked singularities
-@test is_naked_singularity(BoyerLindquistAD(1.0, 0.0)) == false
-@test is_naked_singularity(JohannsenPsaltisAD(1.0, 0.998, 2.0)) == true
+@test is_naked_singularity(KerrSpacetime(1.0, 0.0)) == false
+@test is_naked_singularity(JohannsenPsaltisMetric(1.0, 0.998, 2.0)) == true

--- a/test/test-special-radii.jl
+++ b/test/test-special-radii.jl
@@ -3,18 +3,18 @@ using Gradus
 using StaticArrays
 
 # test known radii
-m = KerrSpacetime(M = 1.0, a = 0.0)
+m = KerrMetric(M = 1.0, a = 0.0)
 @test Gradus.isco(m) == 6.0
 
-m = KerrSpacetime(M = 1.0, a = 1.0)
+m = KerrMetric(M = 1.0, a = 1.0)
 @test Gradus.isco(m) == 1.0
 
 # test event horizon code
-m = KerrSpacetime(M = 1.0, a = 0.0)
+m = KerrMetric(M = 1.0, a = 0.0)
 rs, _ = event_horizon(m)
 @test rs ≈ fill(2.0, length(rs))
 
-m = KerrSpacetime(M = 1.0, a = 1.0)
+m = KerrMetric(M = 1.0, a = 1.0)
 rs, _ = event_horizon(m)
 @test rs ≈ fill(1.0, length(rs))
 
@@ -26,5 +26,5 @@ for M in [JohannsenMetric, JohannsenPsaltisMetric]
 end
 
 # test naked singularities
-@test is_naked_singularity(KerrSpacetime(1.0, 0.0)) == false
+@test is_naked_singularity(KerrMetric(1.0, 0.0)) == false
 @test is_naked_singularity(JohannsenPsaltisMetric(1.0, 0.998, 2.0)) == true

--- a/test/test-special-radii.jl
+++ b/test/test-special-radii.jl
@@ -12,11 +12,11 @@ m = KerrMetric(M = 1.0, a = 1.0)
 # test event horizon code
 m = KerrMetric(M = 1.0, a = 0.0)
 rs, _ = event_horizon(m)
-@test rs ≈ fill(2.0, length(rs))
+@test rs ≈ fill(2.0, length(rs)) rtol = 0.01
 
 m = KerrMetric(M = 1.0, a = 1.0)
 rs, _ = event_horizon(m)
-@test rs ≈ fill(1.0, length(rs))
+@test rs ≈ fill(1.0, length(rs)) rtol = 0.01
 
 # make sure works for other metrics too
 for M in [JohannsenMetric, JohannsenPsaltisMetric]

--- a/test/test-special-radii.jl
+++ b/test/test-special-radii.jl
@@ -1,0 +1,30 @@
+using Test
+using Gradus
+using StaticArrays
+
+# test known radii
+m = BoyerLindquistAD(M = 1.0, a = 0.0)
+@test Gradus.isco(m) == 6.0
+
+m = BoyerLindquistAD(M = 1.0, a = 1.0)
+@test Gradus.isco(m) == 1.0
+
+# test event horizon code
+m = BoyerLindquistAD(M = 1.0, a = 0.0)
+rs, _ = event_horizon(m)
+@test rs ≈ fill(2.0, length(rs))
+
+m = BoyerLindquistAD(M = 1.0, a = 1.0)
+rs, _ = event_horizon(m)
+@test rs ≈ fill(1.0, length(rs))
+
+# make sure works for other metrics too
+for M in [JohannsenAD, JohannsenPsaltisAD]
+    @test Gradus.isco(M()) > 1.0
+    _rs, _ = event_horizon(M())
+    @test (_rs .> 1.0) |> all
+end
+
+# test naked singularities
+@test is_naked_singularity(BoyerLindquistAD(1.0, 0.0)) == false
+@test is_naked_singularity(JohannsenPsaltisAD(1.0, 0.998, 2.0)) == true

--- a/test/unit/gradusbase.geometry.jl
+++ b/test/unit/gradusbase.geometry.jl
@@ -8,8 +8,8 @@ using Tullio
         # can't do first order yet since no four velocity
         # KerrSpacetimeFirstOrder(1.0, 0.998, 1.0),
         # KerrSpacetimeFirstOrder(1.0, -0.998, 1.0),
-        KerrSpacetime(1.0, 0.998),
-        KerrSpacetime(1.0, -0.998),
+        KerrMetric(1.0, 0.998),
+        KerrMetric(1.0, -0.998),
         JohannsenMetric(M = 1.0, a = 0.998, α13 = 1.0),
         JohannsenMetric(M = 1.0, a = 0.998, α22 = 1.0),
         # DilatonAxion(M = 1.0, a = 0.998, β = 0.2, b = 1.0),
@@ -74,7 +74,7 @@ using Tullio
         end
 
         for M = 0.2:0.8:2.0, a = -M:0.5:M
-            m = KerrSpacetime(M, a)
+            m = KerrMetric(M, a)
             r = inner_radius(m) + 4.2
             for θ in angles
                 u = @SVector [0.0, r, θ, 0.0]
@@ -108,7 +108,7 @@ using Tullio
         end
 
         for M = 0.2:0.8:2.0, a = -M:0.5:M
-            m = KerrSpacetime(M, a)
+            m = KerrMetric(M, a)
             r = inner_radius(m) + 0.3
             for θ in angles
                 u = @SVector [0.0, r, θ, 0.1]

--- a/test/unit/gradusbase.geometry.jl
+++ b/test/unit/gradusbase.geometry.jl
@@ -6,13 +6,13 @@ using Tullio
 @testset "tetradframe" begin
     all_metrics = (
         # can't do first order yet since no four velocity
-        # BoyerLindquistFO(1.0, 0.998, 1.0),
-        # BoyerLindquistFO(1.0, -0.998, 1.0),
-        BoyerLindquistAD(1.0, 0.998),
-        BoyerLindquistAD(1.0, -0.998),
-        JohannsenAD(M = 1.0, a = 0.998, α13 = 1.0),
-        JohannsenAD(M = 1.0, a = 0.998, α22 = 1.0),
-        # DilatonAxionAD(M = 1.0, a = 0.998, β = 0.2, b = 1.0),
+        # KerrSpacetimeFirstOrder(1.0, 0.998, 1.0),
+        # KerrSpacetimeFirstOrder(1.0, -0.998, 1.0),
+        KerrSpacetime(1.0, 0.998),
+        KerrSpacetime(1.0, -0.998),
+        JohannsenMetric(M = 1.0, a = 0.998, α13 = 1.0),
+        JohannsenMetric(M = 1.0, a = 0.998, α22 = 1.0),
+        # DilatonAxion(M = 1.0, a = 0.998, β = 0.2, b = 1.0),
     )
     radii = 5.0:0.8:10.0
     angles = 0.1:0.5:π
@@ -74,7 +74,7 @@ using Tullio
         end
 
         for M = 0.2:0.8:2.0, a = -M:0.5:M
-            m = BoyerLindquistAD(M, a)
+            m = KerrSpacetime(M, a)
             r = inner_radius(m) + 4.2
             for θ in angles
                 u = @SVector [0.0, r, θ, 0.0]
@@ -108,7 +108,7 @@ using Tullio
         end
 
         for M = 0.2:0.8:2.0, a = -M:0.5:M
-            m = BoyerLindquistAD(M, a)
+            m = KerrSpacetime(M, a)
             r = inner_radius(m) + 0.3
             for θ in angles
                 u = @SVector [0.0, r, θ, 0.1]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,4 @@
 function count_inner_boundary(m, simsols)
-    points = getgeodesicpoint.(m, simsols.u)
+    points = process_solution.(m, simsols.u)
     count(i -> i.status == StatusCodes.WithinInnerBoundary, points)
 end


### PR DESCRIPTION
Working towards #68, remove the majority of those unused `where {T}` captures, and renamed a handful of functions to be more descriptive. This includes the names for the different metrics, which should now be consistent and also ommit needing to think about implementation details (the `*AD` or `*FO` tails). 

Restructured some of the tests and reduced the resolution of the traces to hopefully speed the suite up a little. Added some tests for inference.