### PR TITLE
Feat: better put out the bins for garbage collection

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -23,6 +23,5 @@ QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 VoronoiCells = "e3e34ffb-84e9-5012-9490-92c94d0c60a4"

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -24,7 +24,6 @@ using MuladdMacro
 using Accessors: @set
 using Tullio: @tullio
 
-import Transducers
 import ForwardDiff
 import GeometryBasics
 

--- a/src/GradusBase/geodesic-solutions.jl
+++ b/src/GradusBase/geodesic-solutions.jl
@@ -70,10 +70,11 @@ Used to get pack a `SciMLBase.AbstractODESolution` into a [`GeodesicPoint`](@ref
 information relevant to start and endpoint of the integration. To keep the full geodesic path, it is
 encouraged to use the `SciMLBase.AbstractODESolution` directly.
 """
-function process_solution(
-    _::AbstractMetricParams{T},
-    sol::SciMLBase.AbstractODESolution{T,N,S},
-) where {T,N,S}
+function process_solution(_::AbstractMetricParams, sol::SciMLBase.AbstractODESolution)
+    process_solution(sol)
+end
+
+function process_solution(sol::SciMLBase.AbstractODESolution{T,N,S}) where {T,N,S}
     @inbounds @views begin
         us, ts, _ = unpack_solution(sol)
 

--- a/src/accretion-geometry/bootstrap.jl
+++ b/src/accretion-geometry/bootstrap.jl
@@ -1,15 +1,21 @@
-function tracegeodesics(
+function geodesic_problem(
     m::AbstractMetricParams,
     u,
     v,
     accretion_geometry::AbstractAccretionGeometry,
     time_domain::NTuple{2};
-    callback = nothing,
     gtol = 1e-2,
-    kwargs...,
+    callback = nothing,
+    solver_opts...,
 )
-    cbs = add_collision_callback(callback, accretion_geometry; gtol = gtol)
-    tracegeodesics(m, u, v, time_domain; callback = cbs, kwargs...)
+    geodesic_problem(
+        m,
+        u,
+        v,
+        time_domain;
+        callback = add_collision_callback(callback, accretion_geometry; gtol = gtol),
+        solver_opts...,
+    )
 end
 
 function rendergeodesics(

--- a/src/image-planes/planes.jl
+++ b/src/image-planes/planes.jl
@@ -103,7 +103,7 @@ function tracegeodesics(
     m::AbstractMetricParams,
     observer_position,
     plane::AbstractImagePlane,
-    time_domain::NTuple{2};
+    args...;
     kwargs...,
 )
     αs, βs = impact_parameters(plane, observer_position)
@@ -112,7 +112,7 @@ function tracegeodesics(
         m,
         observer_position,
         velfunc,
-        time_domain;
+        args...;
         trajectories = trajectory_count(plane),
         kwargs...,
     )

--- a/src/line-profiles.jl
+++ b/src/line-profiles.jl
@@ -58,8 +58,15 @@ function lineprofile(
     redshift_pf = ConstPointFunctions.redshift(m, u),
     kwargs...,
 )
-    simsols = tracegeodesics(m, u, plane, d, (0.0, λ_max); save_on = false)
-    gps = process_solution.(m, simsols.u)
+    gps = tracegeodesics(
+        m,
+        u,
+        plane,
+        d,
+        (0.0, λ_max);
+        save_on = false,
+        ensemble = EnsembleEndpointThreads(),
+    )
 
     I = [i.status == StatusCodes.IntersectedWithGeometry for i in gps]
     points = @views gps[I]

--- a/src/tracing/constraints.jl
+++ b/src/tracing/constraints.jl
@@ -1,5 +1,10 @@
 # vectors of vectors 
-function constrain_all(m::AbstractMetricParams, us::AbstractArray{<:StaticVector}, vs::AbstractArray{<:StaticVector}, μ)
+function constrain_all(
+    m::AbstractMetricParams,
+    us::AbstractArray{<:StaticVector},
+    vs::AbstractArray{<:StaticVector},
+    μ,
+)
     @inbounds for i in eachindex(vs)
         vs[i] = constrain_all(m, us[i], vs[i], μ)
     end

--- a/src/tracing/method-implementations/first-order.jl
+++ b/src/tracing/method-implementations/first-order.jl
@@ -88,23 +88,17 @@ function integrator_problem(
     m::AbstractFirstOrderMetricParams{T},
     pos::StaticVector{S,T},
     vel::StaticVector{S,T},
-    time_domain,
+    time_domain;
+    kwargs...,
 ) where {S,T}
     L, Q = calc_lq(m, pos, vel)
-    ODEProblem{false}(pos, time_domain, make_parameters(L, Q, vel[2], T)) do u, p, λ
+    ODEProblem{false}(
+        pos,
+        time_domain,
+        make_parameters(L, Q, vel[2], T);
+        kwargs...,
+    ) do u, p, λ
         SVector(four_velocity(u, m, p)...)
-    end
-end
-
-function integrator_problem(
-    m::AbstractFirstOrderMetricParams{T},
-    pos::AbstractVector{T},
-    vel::AbstractVector{T},
-    time_domain,
-) where {T}
-    L, Q = calc_lq(m, pos, vel)
-    ODEProblem{true}(pos, time_domain, make_parameters(L, Q, vel[2], T)) do du, u, p, λ
-        du .= four_velocity(u, m, p)
     end
 end
 

--- a/src/tracing/tracing.jl
+++ b/src/tracing/tracing.jl
@@ -26,47 +26,65 @@ specifying the ensemble method to use.
 `solver_opts` are the common solver options in DifferentialEquations.
 """
 function tracegeodesics(
-    m::AbstractMetricParams{T},
+    m::AbstractMetricParams,
     position,
-    velocity,
+    velocity::V,
     time_domain::NTuple{2};
     solver = Tsit5(),
+    ensemble = EnsembleThreads(),
+    trajectories = nothing,
     μ = 0.0,
     closest_approach = 1.01,
     effective_infinity = 1200.0,
     callback = nothing,
     solver_opts...,
-) where {T}
-    _velocity = if (velocity isa Function) && (eltype(position) === T)
-        wrap_constraint(m, position, velocity, μ)
-    else
-        if eltype(position) !== eltype(velocity)
-            error(
-                "Position and velocity must have the same element type.\n(u: $(typeof(position)), v: $(typeof(velocity)))",
-            )
-        end
-        constrain_all(m, position, velocity, μ)
-    end
-
-    cbs = create_callback_set(m, callback, closest_approach, effective_infinity)
-    __tracegeodesics(
+) where {V}
+    problem = geodesic_problem(
         m,
         position,
-        _velocity,
-        time_domain,
-        solver;
-        callback = cbs,
-        abstol = 1e-9,
-        reltol = 1e-9,
-        solver_opts...,
+        velocity,
+        time_domain;
+        μ = μ,
+        closest_approach = closest_approach,
+        effective_infinity = effective_infinity,
+        callback = callback,
     )
+    # how many trajectories
+    if V <: Function
+        if isnothing(trajectories)
+            error("When velocity is a function, trajectories must be defined")
+        end
+        solve_geodesic_problem(
+            problem,
+            solver,
+            ensemble;
+            trajectories = trajectories,
+            solver_opts...,
+        )
+    elseif !(V <: SVector) && V <: AbstractVector
+        solve_geodesic_problem(
+            problem,
+            solver,
+            ensemble;
+            trajectories = length(velocity),
+            solver_opts...,
+        )
+    else
+        if !isnothing(trajectories)
+            error(
+                "Trajectories should be `nothing` when solving only a single geodesic problem.",
+            )
+        end
+        solve_geodesic_problem(problem, solver; solver_opts...)
+    end
 end
 
 function integrator_problem(
     m::AbstractMetricParams{T},
     pos::StaticVector{S,T},
     vel::StaticVector{S,T},
-    time_domain,
+    time_domain;
+    kwargs...,
 ) where {S,T}
     u_init = vcat(pos, vel)
 
@@ -78,77 +96,95 @@ function integrator_problem(
         end
     end
 
-    ODEProblem{false}(f, u_init, time_domain, IntegrationParameters(StatusCodes.NoStatus))
-end
-
-# single position and single velocity
-function __tracegeodesics(
-    m::AbstractMetricParams{T},
-    init_pos::AbstractVector{T},
-    init_vel::AbstractVector{T},
-    time_domain::NTuple{2},
-    solver;
-    kwargs...,
-) where {T<:Number}
-    prob = integrator_problem(m, init_pos, init_vel, time_domain)
-    solve_geodesic(solver, prob; kwargs...)
-end
-
-# single position and single velocity
-# ensembled with an indexable function
-function __tracegeodesics(
-    m::AbstractMetricParams{T},
-    init_pos::AbstractVector{T},
-    vel_func::Function,
-    time_domain::NTuple{2},
-    solver;
-    trajectories::Int,
-    ensemble = EnsembleThreads(),
-    kwargs...,
-) where {T<:Number}
-    prob = integrator_problem(m, init_pos, vel_func(1), time_domain)
-    ens_prob = EnsembleProblem(
-        prob,
-        prob_func = (prob, i, repeat) ->
-            integrator_problem(m, init_pos, vel_func(i), time_domain),
-        safetycopy = false,
-    )
-    solve_geodesic(solver, ens_prob, ensemble; trajectories = trajectories, kwargs...)
-end
-
-# indexables
-function __tracegeodesics(
-    m::AbstractMetricParams{T},
-    init_positions,
-    init_velocities,
-    time_domain::NTuple{2},
-    solver;
-    ensemble = EnsembleThreads(),
-    kwargs...,
-) where {T}
-    prob = integrator_problem(m, init_positions[1], init_velocities[1], time_domain)
-    ens_prob = EnsembleProblem(
-        prob,
-        prob_func = (prob, i, repeat) ->
-            integrator_problem(m, init_positions[i], init_velocities[i], time_domain),
-        safetycopy = false,
-    )
-
-    solve_geodesic(
-        solver,
-        ens_prob,
-        ensemble;
-        trajectories = length(init_velocities),
+    ODEProblem{false}(
+        f,
+        u_init,
+        time_domain,
+        IntegrationParameters(StatusCodes.NoStatus);
         kwargs...,
     )
 end
 
+function geodesic_problem(
+    m::AbstractMetricParams,
+    init_pos::U,
+    init_vel::V,
+    time_domain::NTuple{2};
+    closest_approach = 1.01,
+    effective_infinity = 1200.0,
+    callback = nothing,
+    μ = 0.0,
+) where {U,V}
+    # create the callback set for the problem
+    cbs = create_callback_set(m, callback, closest_approach, effective_infinity)
+
+    if U <: SVector && V <: SVector
+        # single position and velocity
+        return integrator_problem(
+            m,
+            init_pos,
+            constrain_all(m, init_pos, init_vel, μ),
+            time_domain;
+            callback = cbs,
+        )
+    elseif U <: SVector && V <: Function
+        # single position, velocity generating function
+        _vfunc = wrap_constraint(m, init_pos, init_vel, μ)
+        prob = integrator_problem(m, init_pos, _vfunc(1), time_domain)
+        ens_prob = EnsembleProblem(
+            prob,
+            prob_func = (prob, i, repeat) ->
+                integrator_problem(m, init_pos, _vfunc(i), time_domain, callback = cbs),
+            safetycopy = false,
+        )
+        return ens_prob
+    elseif U === V
+        # both are arrays of SVectors
+        _vels = constrain_all(m, init_pos, init_vel, μ)
+        prob = integrator_problem(m, init_pos[1], _vels[1], time_domain, callback = cbs)
+        ens_prob = EnsembleProblem(
+            prob,
+            prob_func = (prob, i, repeat) -> integrator_problem(
+                m,
+                init_pos[i],
+                _vels[i],
+                time_domain,
+                callback = cbs,
+            ),
+            safetycopy = false,
+        )
+        return ens_prob
+    end
+end
+
 # ensemble dispatch
-solve_geodesic(solver, prob, ensemble; solver_opts...) =
-    solve(prob, solver, ensemble; solver_opts..., kwargshandle = KeywordArgError)
+@inline solve_geodesic_problem(
+    prob,
+    solver,
+    ensemble;
+    abstol = 1e-9,
+    reltol = 1e-9,
+    solver_opts...,
+) = solve(
+    prob,
+    solver,
+    ensemble;
+    abstol = abstol,
+    reltol = reltol,
+    solver_opts...,
+    kwargshandle = KeywordArgError,
+)
 
 # non-ensemble dispatch
-solve_geodesic(solver, prob; solver_opts...) =
-    solve(prob, solver, ; solver_opts..., kwargshandle = KeywordArgError)
+@inline solve_geodesic_problem(prob, solver; abstol = 1e-9, reltol = 1e-9, solver_opts...) =
+    solve(
+        prob,
+        solver,
+        ;
+        abstol = abstol,
+        reltol = reltol,
+        solver_opts...,
+        kwargshandle = KeywordArgError,
+    )
 
-export tracegeodesics
+export tracegeodesics, geodesic_problem

--- a/src/tracing/utility.jl
+++ b/src/tracing/utility.jl
@@ -18,8 +18,7 @@ function map_impact_parameters(
     α::AbstractVector{P},
     β::AbstractVector{P},
 ) where {T,P}
-    curried(_α, _β) = map_impact_parameters(m, u, _α, _β)
-    curried.(α, β)
+    [map_impact_parameters(m, u, a, b) for (a, b) in zip(α, β)]
 end
 
 @inline function impact_parameters_to_vel(m::AbstractMetricParams{T}, u, α, β) where {T}

--- a/src/transfer-functions/transfer-functions-2d.jl
+++ b/src/transfer-functions/transfer-functions-2d.jl
@@ -47,20 +47,18 @@ function source_to_disc(
     sampler = EvenSampler(domain = BothHemispheres(), generator = RandomGenerator()),
     solver_opts...,
 )
-    sols = tracegeodesics(
+    all_points = tracegeodesics(
         m,
         model,
         d,
         (0.0, max_t);
         n_samples = n_samples,
         save_on = false,
+        ensemble = EnsembleEndpointThreads(),
         sampler = sampler,
         solver_opts...,
     )
-    points = filter(
-        i -> i.status == StatusCodes.IntersectedWithGeometry,
-        process_solution.(m, sols.u),
-    )
+    points = filter(i -> i.status == StatusCodes.IntersectedWithGeometry, all_points)
     # sort by radius
     sort!(points, by = i -> i.u2[2])
     points
@@ -75,8 +73,16 @@ function observer_to_disc(
     ;
     solver_opts...,
 )
-    sols = tracegeodesics(m, u, plane, d, (0.0, max_t); save_on = false, solver_opts...)
-    points = process_solution.(m, sols.u)
+    points = tracegeodesics(
+        m,
+        u,
+        plane,
+        d,
+        (0.0, max_t);
+        save_on = false,
+        ensemble = EnsembleEndpointThreads(),
+        solver_opts...,
+    )
     points
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,10 @@
 
-@inline function _threaded_map(f, itr)::Vector{Base.@default_eltype(Base.Generator(f, itr))}
-    # see https://github.com/JuliaFolds/Transducers.jl/issues/13
-    Transducers.tcollect(itr |> Transducers.Map(f))
+@inline function _threaded_map(f, itr)
+    N = length(itr)
+    items = !(typeof(itr) <: AbstractArray) ? collect(itr) : itr
+    output = Vector{Core.Compiler.return_type(f, Tuple{eltype(items)})}(undef, N)
+    Threads.@threads for i = 1:N
+        @inbounds output[i] = f(items[i])
+    end
+    output
 end


### PR DESCRIPTION
```julia
using Gradus

m = KerrMetric(M = 1.0, a = 1.0)
u = @SVector [0.0, 1e6, deg2rad(60), 0.0]
d = GeometricThinDisc(Gradus.isco(m), 500.0, deg2rad(90.0))

model = LampPostModel()
plane = PolarPlane(GeometricGrid(); Nr = 800, Nθ = 800)

begin
    GC.gc()
    tf = @time lagtransfer(model, m, u, plane, d, callback = domain_upper_hemisphere())
end

# old
#  44.711429 seconds (18.92 M allocations: 6.857 GiB, 17.81% gc time)
# new
#  34.577995 seconds (7.88 M allocations: 1.671 GiB)
```

This might start getting quite confusing, but there is now a new ensemble method in Gradus which reuses integrators _provided only the endpoints of the geodesic_ are needed -- `EnsembleEndpointThreads`. This saves a considerable number of allocations, as can be seen above.

The same principle could also be used anywhere where the full solutions aren't required, such as in the precision integrators -- instead of setting up a full solution again, we just `init` and `reinit` as needed.

I will add that to the next PR to improve those methods.

Is a step towards #82 👍 