### PR TITLE
Feat: render unto first-order

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/benchmark/integrator/benchmark-tracing.jl
+++ b/benchmark/integrator/benchmark-tracing.jl
@@ -23,7 +23,10 @@ tracing_suite["single-geodesic"]["with-disc-no-save"] =
 
 # many positions, many velocities
 
-vs = vec([map_impact_parameters(m, u, a, b) for a in range(-11.0, 11.0, 128) for b in range(-11.0, 11.0, 128)])
+vs = vec([
+    map_impact_parameters(m, u, a, b) for a in range(-11.0, 11.0, 128) for
+    b in range(-11.0, 11.0, 128)
+])
 us = fill(u, length(vs))
 
 tracing_suite["many-geodesic"] = BenchmarkGroup(["tracing"])
@@ -36,6 +39,21 @@ tracing_suite["many-geodesic"]["with-disc"] =
 tracing_suite["many-geodesic"]["with-disc-no-save"] =
     @benchmarkable tracegeodesics($m, $us, $vs, $d, $time_span; save_on = false)
 tracing_suite["many-geodesic"]["with-disc-no-save-ensemble-endpoint"] =
-    @benchmarkable tracegeodesics($m, $us, $vs, $d, $time_span; save_on = false, ensemble = Gradus.EnsembleEndpointThreads())
+    @benchmarkable tracegeodesics(
+        $m,
+        $us,
+        $vs,
+        $d,
+        $time_span;
+        save_on = false,
+        ensemble = Gradus.EnsembleEndpointThreads(),
+    )
 tracing_suite["many-geodesic"]["no-disc-no-save-ensemble-endpoint"] =
-    @benchmarkable tracegeodesics($m, $us, $vs, $time_span; save_on = false, ensemble = Gradus.EnsembleEndpointThreads())
+    @benchmarkable tracegeodesics(
+        $m,
+        $us,
+        $vs,
+        $time_span;
+        save_on = false,
+        ensemble = Gradus.EnsembleEndpointThreads(),
+    )

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -10,5 +10,5 @@ suite = BenchmarkGroup()
 suite["tracing"] = tracing_suite
 
 # run and display
-results = run(suite, verbose=true)
+results = run(suite, verbose = true)
 display(results)

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -57,7 +57,9 @@ import .GradusBase:
     raiseindices,
     StatusCodes,
     AbstractIntegrationParameters,
-    IntegrationParameters
+    IntegrationParameters,
+    update_integration_parameters!,
+    restric_ensemble
 
 export AbstractMetricParams,
     process_solution,

--- a/src/GradusBase/GradusBase.jl
+++ b/src/GradusBase/GradusBase.jl
@@ -46,6 +46,9 @@ lnrframe,
 lowerindices,
 raiseindices,
 StatusCodes,
-IntegrationParameters
+AbstractIntegrationParameters,
+IntegrationParameters,
+update_integration_parameters!,
+restric_ensemble
 
 end # module

--- a/src/GradusBase/geodesic-solutions.jl
+++ b/src/GradusBase/geodesic-solutions.jl
@@ -64,17 +64,14 @@ function Base.show(io::IO, ::MIME"text/plain", gp::GeodesicPoint)
 end
 
 """
-    $(TYPEDSIGNATURES)
+    process_solution(sol::SciMLBase.AbstractODESolution)
+    process_solution(gp::GeodesicPoint)
 
 Used to get pack a `SciMLBase.AbstractODESolution` into a [`GeodesicPoint`](@ref). Will only store
 information relevant to start and endpoint of the integration. To keep the full geodesic path, it is
 encouraged to use the `SciMLBase.AbstractODESolution` directly.
 """
-function process_solution(_::AbstractMetricParams, sol::SciMLBase.AbstractODESolution)
-    process_solution(sol)
-end
-
-function process_solution(sol::SciMLBase.AbstractODESolution{T,N,S}) where {T,N,S}
+function process_solution(_, sol::SciMLBase.AbstractODESolution{T}) where {T}
     @inbounds @views begin
         us, ts, _ = unpack_solution(sol)
 
@@ -98,8 +95,8 @@ array of [`GeodesicPoint`](@ref).
 """
 function process_solution_full(
     _::AbstractMetricParams{T},
-    sol::SciMLBase.AbstractODESolution{T,N,S},
-) where {T,N,S}
+    sol::SciMLBase.AbstractODESolution{T},
+) where {T}
     us, ts, _ = unpack_solution(sol)
     @inbounds @views begin
         u_start = SVector{4,T}(us[1][1:4])
@@ -113,6 +110,9 @@ function process_solution_full(
         end
     end
 end
+
+process_solution(gp::AbstractGeodesicPoint) = gp
+process_solution(sol::SciMLBase.AbstractODESolution) = process_solution(sol.prob.f.f.m, sol)
 
 # TODO: GeodesicPath structure for the full geodesic path
 # do we want to support this?

--- a/src/GradusBase/geodesic-solutions.jl
+++ b/src/GradusBase/geodesic-solutions.jl
@@ -1,7 +1,20 @@
 abstract type AbstractIntegrationParameters end
 
+update_integration_parameters!(
+    p::AbstractIntegrationParameters,
+    ::AbstractIntegrationParameters,
+) = error("Not implemented for $(typeof(p))")
+
 mutable struct IntegrationParameters <: AbstractIntegrationParameters
     status::StatusCodes.T
+end
+
+function update_integration_parameters!(
+    p::IntegrationParameters,
+    new::IntegrationParameters,
+)
+    p.status = new.status
+    p
 end
 
 """

--- a/src/GradusBase/metric-params.jl
+++ b/src/GradusBase/metric-params.jl
@@ -75,3 +75,5 @@ Numerically evaluate the corresponding metric for [`AbstractMetricParams`](@ref)
 and some point `u`.
 """
 metric(m::AbstractMetricParams, u) = error("Not implemented for metric $(typeof(m))")
+
+restric_ensemble(::AbstractMetricParams, ensemble) = ensemble

--- a/src/rendering/utility.jl
+++ b/src/rendering/utility.jl
@@ -58,5 +58,6 @@ function init_progress_bar(text, N, enabled)
         barlen = 40,
         color = :none,
         enabled = enabled,
+        showspeed = true,
     )
 end

--- a/src/tracing/callbacks.jl
+++ b/src/tracing/callbacks.jl
@@ -11,17 +11,20 @@ end
     effective_infinity,
 )
     min_r = inner_radius(m) * closest_approach
-    # terminate integration if we come within some % of the black hole radius
-    DiscreteCallback(
-        (u, λ, integrator) -> u[2] ≤ min_r || u[2] > effective_infinity,
-        integrator -> if integrator.u[2] ≤ min_r
+    function on_chart(u, λ, integrator)
+        # terminate integration if we come within some % of the black hole radius
+        u[2] ≤ min_r || u[2] > effective_infinity
+    end
+    function chart_terminate!(integrator)
+        if integrator.u[2] ≤ min_r
             integrator.p.status = StatusCodes.WithinInnerBoundary
             terminate!(integrator)
         else
             integrator.p.status = StatusCodes.OutOfDomain
             terminate!(integrator)
-        end,
-    )
+        end
+    end
+    DiscreteCallback(on_chart, chart_terminate!)
 end
 
 function metric_callback(m::AbstractMetricParams, closest_approach, effective_infinity)

--- a/src/tracing/tracing.jl
+++ b/src/tracing/tracing.jl
@@ -56,9 +56,21 @@ function tracegeodesics(
         if isnothing(trajectories)
             error("When velocity is a function, trajectories must be defined")
         end
-        solve_geodesic_problem(problem, solver, ensemble, trajectories; solver_opts...)
+        solve_geodesic_problem(
+            problem,
+            solver,
+            restric_ensemble(m, ensemble),
+            trajectories;
+            solver_opts...,
+        )
     elseif eltype(velocity) <: SVector
-        solve_geodesic_problem(problem, solver, ensemble, length(velocity); solver_opts...)
+        solve_geodesic_problem(
+            problem,
+            solver,
+            restric_ensemble(m, ensemble),
+            length(velocity);
+            solver_opts...,
+        )
     else
         if !isnothing(trajectories)
             error(
@@ -159,10 +171,17 @@ end
     solver_opts...,
 )
     prob = if !isnothing(progress_bar)
-        remake(ens_prob, output_func = (sol, i) -> begin
+        function output_bump_progress(sol, i)
             ProgressMeter.next!(progress_bar)
-            sol, false
-        end)
+            (sol, false)
+        end
+        # bootstrap incrementing progress bar
+        EnsembleProblem(
+            ens_prob.prob;
+            prob_func = ens_prob.prob_func,
+            output_func = output_bump_progress,
+            safetycopy = ens_prob.safetycopy,
+        )
     else
         ens_prob
     end
@@ -229,14 +248,17 @@ end
         1:Threads.nthreads(),
     )
     # pre-allocate all of the returns
-    T = Core.Compiler.return_type(_solve_reinit!, Tuple{eltype(integrators),S})
-    output = Vector{T}(undef, trajectories)
+    output =
+        Vector{Core.Compiler.return_type(_solve_reinit!, Tuple{eltype(integrators),S})}(
+            undef,
+            trajectories,
+        )
 
     # solve
     Threads.@threads for i = 1:trajectories
         integ = integrators[Threads.threadid()]
-        output[i] = _solve_reinit!(integ, pf(prob.prob, i, 0).u0)
-
+        p = pf(prob.prob, i, 0)
+        output[i] = _solve_reinit!(integ, p.u0, p.p)
         # update progress bar 
         if !isnothing(progress_bar)
             ProgressMeter.next!(progress_bar)
@@ -284,7 +306,7 @@ end
     _init_integrator(prob; solver_opts...)
 end
 
-@inline function _solve_reinit!(integrator, u0)
+@inline function _solve_reinit!(integrator, u0, p = nothing)
     reinit!(
         integrator,
         u0,
@@ -294,6 +316,10 @@ end
         reinit_cache = true,
     )
     auto_dt_reset!(integrator)
+    # if new parameters have been passed, update them
+    if !isnothing(p)
+        integrator.p = update_integration_parameters!(integrator.sol.prob.p, p)
+    end
     process_solution(solve!(integrator))
 end
 

--- a/src/tracing/tracing.jl
+++ b/src/tracing/tracing.jl
@@ -149,14 +149,23 @@ end
 
 # ensemble dispatch
 @inline function solve_geodesic_problem(
-    prob,
+    ens_prob::EnsembleProblem,
     solver,
     ensemble,
     trajectories::Int;
     abstol = 1e-9,
     reltol = 1e-9,
+    progress_bar = nothing,
     solver_opts...,
 )
+    prob = if !isnothing(progress_bar)
+        remake(ens_prob, output_func = (sol, i) -> begin
+            ProgressMeter.next!(progress_bar)
+            sol, false
+        end)
+    else
+        ens_prob
+    end
     ensol = solve(
         prob,
         solver,
@@ -172,13 +181,17 @@ end
 
 # non-ensemble dispatch
 @inline function solve_geodesic_problem(
-    prob,
+    prob::ODEProblem,
     solver;
     abstol = 1e-9,
     reltol = 1e-9,
+    progress_bar = nothing,
     solver_opts...,
 )
-    ensol = solve(
+    if !isnothing(progress_bar)
+        @warn "Ignoring progress bar for single geodesic"
+    end
+    sol = solve(
         prob,
         solver,
         ;
@@ -187,22 +200,22 @@ end
         solver_opts...,
         kwargshandle = KeywordArgError,
     )
-    ensol
+    sol
 end
 
 # thread reusing
 @inline function solve_geodesic_problem(
-    prob,
+    prob::EnsembleProblem{<:ODEProblem{S}},
     solver,
     ensemble::EnsembleEndpointThreads,
     trajectories::Int;
     save_on = false,
+    progress_bar = nothing,
     solver_opts...,
-)
+) where {S}
     if save_on
         error("Cannot use `EnsembleEndpointThreads` with `save_on`")
     end
-    N = Threads.nthreads()
     pf = prob.prob_func
     # init one integrator for each thread
     integrators = map(
@@ -213,18 +226,21 @@ end
             save_on = save_on,
             solver_opts...,
         ),
-        1:N,
+        1:Threads.nthreads(),
     )
-
     # pre-allocate all of the returns
-    # T = Core.Compiler.return_type(solve!, Tuple{eltype(integrators)})
-    T = GeodesicPoint{Float64,SVector{4,Float64}}
+    T = Core.Compiler.return_type(_solve_reinit!, Tuple{eltype(integrators),S})
     output = Vector{T}(undef, trajectories)
 
     # solve
     Threads.@threads for i = 1:trajectories
         integ = integrators[Threads.threadid()]
         output[i] = _solve_reinit!(integ, pf(prob.prob, i, 0).u0)
+
+        # update progress bar 
+        if !isnothing(progress_bar)
+            ProgressMeter.next!(progress_bar)
+        end
     end
     output
 end
@@ -244,6 +260,7 @@ end
         abstol = abstol,
         reltol = reltol,
         solver_opts...,
+        kwargshandle = KeywordArgError,
     )
 end
 
@@ -268,7 +285,14 @@ end
 end
 
 @inline function _solve_reinit!(integrator, u0)
-    reinit!(integrator, u0)
+    reinit!(
+        integrator,
+        u0,
+        reset_dt = true,
+        reinit_callbacks = true,
+        erase_sol = true,
+        reinit_cache = true,
+    )
     auto_dt_reset!(integrator)
     process_solution(solve!(integrator))
 end


### PR DESCRIPTION
Tried very hard to get the first order methods to work with the new `EnsembleEndpointThreaded`, but alas, there is some state being shared in the problem parameters within a thread that ruins subsequent solves and i have no idea what is causing it. The only way to fix it is to reinstantiate the integrator after each solve, which just defeats the point of it.

So I've added instead a warning that the endpoint threading method does not work, and then let it automatically change to `EnsembleThreaded`. Made all tests pass.

Also closes #87 -- the progress bar was causing all of the problems, so that can now be optionally passed to `tracegeodesics`, and incremented thread-safe and contextually. This does mean it's now much easier to add new progress meters to other methods too that don't rely on `rendergeodesics`.

Fixed some issues related to half-changes in the `process_solution` API, so that the metric type, if unspecified, is infered from the ODE solution.