### PR TITLE
Feat: charts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.2.7"
+version = "0.2.8"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -144,6 +144,7 @@ include("utils.jl")
 
 include("tracing/tracing.jl")
 include("tracing/constraints.jl")
+include("tracing/charts.jl")
 include("tracing/callbacks.jl")
 include("tracing/utility.jl")
 

--- a/src/line-profiles.jl
+++ b/src/line-profiles.jl
@@ -56,7 +56,7 @@ function lineprofile(
     plane = PolarPlane(GeometricGrid(); Nr = 250, Nθ = 1300, r_max = 50.0),
     λ_max = 2 * u[2],
     redshift_pf = ConstPointFunctions.redshift(m, u),
-    verbose=false,
+    verbose = false,
     minrₑ = isco(m),
     maxrₑ = 50,
     solver_args...,
@@ -70,13 +70,15 @@ function lineprofile(
         d,
         (0.0, λ_max);
         save_on = false,
-        verbose=verbose,
+        verbose = verbose,
         progress_bar = progress_bar,
         ensemble = EnsembleEndpointThreads(),
         solver_args...,
     )
 
-    I = [(i.status == StatusCodes.IntersectedWithGeometry) && (minrₑ <= i.u2[2] <= maxrₑ) for i in gps]
+    I = [
+        (i.status == StatusCodes.IntersectedWithGeometry) && (minrₑ <= i.u2[2] <= maxrₑ) for i in gps
+    ]
     points = @views gps[I]
     areas = unnormalized_areas(plane)[I]
 

--- a/src/orbits/orbit-interpolations.jl
+++ b/src/orbits/orbit-interpolations.jl
@@ -64,7 +64,7 @@ function interpolate_plunging_velocities(
         μ = 1.0,
         reltol = reltol,
         # ensure we gets sufficiently close to the event horizon
-        closest_approach = 1.000001,
+        chart = chart_for_metric(m; closest_approach = 1.000001),
         kwargs...,
     )
 

--- a/src/special-radii.jl
+++ b/src/special-radii.jl
@@ -17,8 +17,8 @@ function isco(m::AbstractAutoDiffStaticAxisSymmetricParams, lower_bound, upper_b
     Roots.find_zero((dE, d2E), (lower_bound, upper_bound))
 end
 
-isco(m::AbstractAutoDiffStaticAxisSymmetricParams) =
-    isco(m, find_lower_isco_bound(m), 100.0)
+isco(m::AbstractAutoDiffStaticAxisSymmetricParams; kwargs...) =
+    isco(m, find_lower_isco_bound(m; kwargs...), 100.0)
 
 """
     $(TYPEDSIGNATURES)

--- a/src/tracing/callbacks.jl
+++ b/src/tracing/callbacks.jl
@@ -6,11 +6,11 @@ function terminate_with_status!(status::StatusCodes.T)
 end
 
 # this function gets specialised for different metric parameters types, e.g. for first order
-@inline function metric_callback(::AbstractMetricParams, chart)
+@inline function metric_callback(::AbstractMetricParams, chart::AbstractChart)
     chart_callback(chart)
 end
 
-function create_callback_set(m::AbstractMetricParams, cb::C, chart) where {C}
+function create_callback_set(m::AbstractMetricParams, cb::C, chart::AbstractChart) where {C}
     mcb = metric_callback(m, chart)
     if C <: SciMLBase.DECallback
         mcb isa Tuple ? CallbackSet(cb, mcb...) : CallbackSet(cb, mcb)

--- a/src/tracing/callbacks.jl
+++ b/src/tracing/callbacks.jl
@@ -5,39 +5,13 @@ function terminate_with_status!(status::StatusCodes.T)
     end
 end
 
-@inline function ensure_chart_callback(
-    m::AbstractMetricParams,
-    closest_approach,
-    effective_infinity,
-)
-    min_r = inner_radius(m) * closest_approach
-    function on_chart(u, λ, integrator)
-        # terminate integration if we come within some % of the black hole radius
-        u[2] ≤ min_r || u[2] > effective_infinity
-    end
-    function chart_terminate!(integrator)
-        if integrator.u[2] ≤ min_r
-            integrator.p.status = StatusCodes.WithinInnerBoundary
-            terminate!(integrator)
-        else
-            integrator.p.status = StatusCodes.OutOfDomain
-            terminate!(integrator)
-        end
-    end
-    DiscreteCallback(on_chart, chart_terminate!)
+# this function gets specialised for different metric parameters types, e.g. for first order
+@inline function metric_callback(::AbstractMetricParams, chart)
+    chart_callback(chart)
 end
 
-function metric_callback(m::AbstractMetricParams, closest_approach, effective_infinity)
-    ensure_chart_callback(m, closest_approach, effective_infinity)
-end
-
-function create_callback_set(
-    m::AbstractMetricParams,
-    cb::C,
-    closest_approach,
-    effective_infinity,
-) where {C}
-    mcb = metric_callback(m, closest_approach, effective_infinity)
+function create_callback_set(m::AbstractMetricParams, cb::C, chart) where {C}
+    mcb = metric_callback(m, chart)
     if C <: SciMLBase.DECallback
         mcb isa Tuple ? CallbackSet(cb, mcb...) : CallbackSet(cb, mcb)
     elseif C <: Tuple

--- a/src/tracing/charts.jl
+++ b/src/tracing/charts.jl
@@ -1,0 +1,34 @@
+abstract type AbstractChart end
+
+struct PolarChart{T} <: AbstractChart
+    inner_radius::T
+    outer_radius::T
+end
+
+@inline function chart_callback(chart::PolarChart)
+    function on_chart(u, λ, integrator)
+        # terminate integration if we come within some % of the black hole radius
+        u[2] ≤ chart.inner_radius || u[2] > chart.outer_radius
+    end
+    function chart_terminate!(integrator)
+        # terminate with status code depending on whether inner or outer boundary
+        if integrator.u[2] ≤ chart.inner_radius
+            integrator.p.status = StatusCodes.WithinInnerBoundary
+            terminate!(integrator)
+        else
+            integrator.p.status = StatusCodes.OutOfDomain
+            terminate!(integrator)
+        end
+    end
+    DiscreteCallback(on_chart, chart_terminate!)
+end
+
+function chart_for_metric(
+    m::AbstractMetricParams{T},
+    outer_radius = 1200.0;
+    closest_approach = 1.01,
+) where {T}
+    chart =
+        PolarChart(GradusBase.inner_radius(m) * closest_approach, convert(T, outer_radius))
+    chart
+end

--- a/src/tracing/charts.jl
+++ b/src/tracing/charts.jl
@@ -23,6 +23,31 @@ end
     DiscreteCallback(on_chart, chart_terminate!)
 end
 
+struct PoloidalShapeChart{T,F} <: AbstractChart
+    shapefunc::F
+    outer_radius::T
+end
+
+@inline function chart_callback(chart::PoloidalShapeChart)
+    function on_chart(u, λ, integrator)
+        # terminate integration if we come within some % of the black hole radius
+        rmin = chart.shapefunc(u[3])
+        u[2] ≤ rmin || u[2] > chart.outer_radius
+    end
+    function chart_terminate!(integrator)
+        # terminate with status code depending on whether inner or outer boundary
+        rmin = chart.shapefunc(integrator.u[3])
+        if integrator.u[2] ≤ rmin
+            integrator.p.status = StatusCodes.WithinInnerBoundary
+            terminate!(integrator)
+        else
+            integrator.p.status = StatusCodes.OutOfDomain
+            terminate!(integrator)
+        end
+    end
+    DiscreteCallback(on_chart, chart_terminate!)
+end
+
 function chart_for_metric(
     m::AbstractMetricParams{T},
     outer_radius = 1200.0;
@@ -32,3 +57,16 @@ function chart_for_metric(
         PolarChart(GradusBase.inner_radius(m) * closest_approach, convert(T, outer_radius))
     chart
 end
+
+function event_horizon_chart(
+    m::AbstractMetricParams;
+    outer_radius = 1200.0,
+    closest_approach = 1.01,
+    kwargs...,
+)
+    rs, θs = event_horizon(m; kwargs...)
+    shapefunc = DataInterpolations.LinearInterpolation(rs .* closest_approach, θs)
+    PoloidalShapeChart(shapefunc, outer_radius)
+end
+
+export event_horizon_chart

--- a/src/tracing/method-implementations/first-order.jl
+++ b/src/tracing/method-implementations/first-order.jl
@@ -70,13 +70,9 @@ end
     )
 end
 
-function metric_callback(
-    m::AbstractFirstOrderMetricParams,
-    closest_approach,
-    effective_infinity,
-)
+function metric_callback(m::AbstractFirstOrderMetricParams, chart)
     (
-        ensure_chart_callback(m, closest_approach, effective_infinity),
+        chart_callback(chart),
         DiscreteCallback(radial_negative_check(m), flip_radial_sign!),
         DiscreteCallback(angular_negative_check(m), flip_angular_sign!),
     )

--- a/src/tracing/method-implementations/first-order.jl
+++ b/src/tracing/method-implementations/first-order.jl
@@ -70,7 +70,7 @@ end
     )
 end
 
-function metric_callback(m::AbstractFirstOrderMetricParams, chart)
+function metric_callback(m::AbstractFirstOrderMetricParams, chart::AbstractChart)
     (
         chart_callback(chart),
         DiscreteCallback(radial_negative_check(m), flip_radial_sign!),

--- a/src/tracing/tracing.jl
+++ b/src/tracing/tracing.jl
@@ -2,14 +2,15 @@ struct EnsembleEndpointThreads end
 
 """
     tracegeodesics(
-        m::AbstractMetricParams{T},
+        m::AbstractMetricParams,
         position,
-        velocity,
-        time_domain::NTuple{2};
+        velocity::V,
+        args...;
         solver = Tsit5(),
+        ensemble = EnsembleThreads(),
+        trajectories = nothing,
         μ = 0.0,
-        closest_approach = 1.01,
-        effective_infinity = 1200.0,
+        chart = chart_for_metric(m),
         callback = nothing,
         solver_opts...,
     )
@@ -36,8 +37,7 @@ function tracegeodesics(
     ensemble = EnsembleThreads(),
     trajectories = nothing,
     μ = 0.0,
-    closest_approach = 1.01,
-    effective_infinity = 1200.0,
+    chart = chart_for_metric(m),
     callback = nothing,
     solver_opts...,
 ) where {V}
@@ -47,8 +47,7 @@ function tracegeodesics(
         velocity,
         args...;
         μ = μ,
-        closest_approach = closest_approach,
-        effective_infinity = effective_infinity,
+        chart = chart,
         callback = callback,
     )
     # how many trajectories
@@ -112,13 +111,12 @@ function geodesic_problem(
     init_pos::U,
     init_vel::V,
     time_domain::NTuple{2};
-    closest_approach = 1.01,
-    effective_infinity = 1200.0,
     callback = nothing,
     μ = 0.0,
+    chart = chart_for_metric(m),
 ) where {U,V}
     # create the callback set for the problem
-    cbs = create_callback_set(m, callback, closest_approach, effective_infinity)
+    cbs = create_callback_set(m, callback, chart)
 
     if U <: SVector && V <: SVector
         # single position and velocity
@@ -291,18 +289,10 @@ end
     u,
     v,
     args...;
-    closest_approach = 1.01,
-    effective_infinity = 1200.0,
+    chart = chart_for_metric(m),
     solver_opts...,
 )
-    prob = geodesic_problem(
-        m,
-        u,
-        v,
-        args...;
-        closest_approach = closest_approach,
-        effective_infinity = effective_infinity,
-    )
+    prob = geodesic_problem(m, u, v, args...; chart = chart)
     _init_integrator(prob; solver_opts...)
 end
 

--- a/src/transfer-functions/cunningham-transfer-functions.jl
+++ b/src/transfer-functions/cunningham-transfer-functions.jl
@@ -174,7 +174,7 @@ function interpolated_transfer_branches(
                 rₑ,
                 ;
                 offset_max = 3rₑ + 20.0,
-                effective_infinity = 10 * u_prob[2],
+                chart = chart_for_metric(m, 10 * u_prob[2]),
                 max_time = 10 * u_prob[2],
                 kwargs...,
             )

--- a/src/transfer-functions/integration.jl
+++ b/src/transfer-functions/integration.jl
@@ -33,7 +33,7 @@ function _cunningham_integrand(f, g, gs, gmin, gmax)
     f * π * (g)^3 / (√(gs * (1 - gs)) * (gmax - gmin))
 end
 
-function integrate_bin(S, gmin, gmax, lo, hi; h = 2e-8, segbuf=nothing)
+function integrate_bin(S, gmin, gmax, lo, hi; h = 2e-8, segbuf = nothing)
     glo = clamp(lo, gmin, gmax)
     ghi = clamp(hi, gmin, gmax)
 
@@ -126,7 +126,8 @@ function integrate_drdg✶(
         for j in eachindex(g_grid_view)
             glo = g_grid[j]
             ghi = g_grid[j+1]
-            flux[j] += integrate_bin(S, gmin, gmax, glo, ghi; h = h, segbuf = segbuf) * weight
+            flux[j] +=
+                integrate_bin(S, gmin, gmax, glo, ghi; h = h, segbuf = segbuf) * weight
         end
     end
 

--- a/src/transfer-functions/transfer-functions-2d.jl
+++ b/src/transfer-functions/transfer-functions-2d.jl
@@ -138,7 +138,7 @@ function lagtransfer(
         plane,
         d,
         max_t;
-        effective_infinity = 1.1 * u[2],
+        chart = chart_for_metric(m, 1.1 * u[2]),
         solver_opts...,
     )
 

--- a/test/integration/test-charts.jl
+++ b/test/integration/test-charts.jl
@@ -1,0 +1,22 @@
+using Gradus
+using Test
+
+# chosen to be close to naked singularity
+m = JohannsenPsaltisMetric(M = 1.0, a = 0.8831, ϵ3 = 0.4)
+u = SVector(0.0, 1000.0, π / 2, 0.0)
+
+_, _, img = rendergeodesics(m, u, 2000.0, image_width = 100, image_height = 100, fov = 6.0)
+# default chart
+@test sum(filter(!isnan, img)) ≈ 2.7725698197810156e6 rtol = 0.0001
+
+_, _, img = rendergeodesics(
+    m,
+    u,
+    2000.0,
+    image_width = 100,
+    image_height = 100,
+    fov = 6.0,
+    chart = event_horizon_chart(m, closest_approach = 1.001, resolution = 100),
+)
+# chart that maps event horizon shape better
+@test sum(filter(!isnan, img)) ≈ 2.762717446130311e6 rtol = 0.0001

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ end
 
 @testset "integration" verbose = true begin
     include("integration/test-inference.jl")
+    include("integration/test-charts.jl")
 end
 
 @testset "transfer-functions" verbose = true begin


### PR DESCRIPTION
Adds `AbstractChart` as a method for changing the integration domain flexibly. Also adds a chart that uses `event_horizon` to interpolate the shape of the inner horizon poloidally, allowing better visualisations of shadows for non spherical event horizons.

```julia
using Gradus
using Plots

m = JohannsenPsaltisMetric(1.0, 0.8831, 0.4)
u = SVector(0.0, 1000.0, π / 2, 0.0)

α, β, img = @time rendergeodesics(
    m,
    u,
    # max integration time
    2000.0,
    image_width = 1000,
    image_height = 1000,
    fov = 60.0 ,
    verbose = true,
    chart = event_horizon_chart(m, closest_approach = 1.001, resolution=200),
)
```

![Screenshot 2023-02-22 at 18 21 08](https://user-images.githubusercontent.com/11492844/220725937-9c3f2fbf-0cdb-429c-be30-814e307e24c4.png)
