### PR TITLE
Feat: disc emissivity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -171,6 +171,7 @@ include("accretion-geometry/discs.jl")
 include("accretion-geometry/meshes.jl")
 include("accretion-geometry/bootstrap.jl")
 
+include("transfer-functions/types.jl")
 include("transfer-functions/cunningham-transfer-functions.jl")
 include("transfer-functions/integration.jl")
 include("transfer-functions/precision-solvers.jl")
@@ -178,6 +179,7 @@ include("transfer-functions/precision-solvers.jl")
 include("corona-to-disc/sky-geometry.jl")
 include("corona-to-disc/corona-models.jl")
 include("corona-to-disc/disc-profiles.jl")
+# needs the types from disc profiles so defer include
 include("transfer-functions/transfer-functions-2d.jl")
 include("corona-to-disc/flux-calculations.jl")
 

--- a/src/corona-to-disc/corona-models.jl
+++ b/src/corona-to-disc/corona-models.jl
@@ -64,4 +64,22 @@ function source_velocity(m::AbstractMetricParams, model::LampPostModel)
     inv(√(-gcomp[1])) * @SVector[1.0, 0.0, 0.0, 0.0]
 end
 
+# this function is a placeholder: needs to be able to work
+# for any disc geometry and model type
+function energy_ratio(m, gps, model::LampPostModel)
+    energy_ratio(m, gps, SVector(0.0, model.h, model.θ, 0.0), source_velocity(m, model))
+end
+function energy_ratio(m, gps, u_src, v_src)
+    g_src = metric(m, u_src)
+    map(gps) do gp
+        @tullio e_src := g_src[i, j] * gp.v1[i] * v_src[j]
+        # at the disc
+        g_disc = metric(m, gp.u2)
+        v_disc = CircularOrbits.fourvelocity(m, SVector(gp.u2[2], gp.u2[3]))
+        @tullio e_disc := g_disc[i, j] * gp.v2[i] * v_disc[j]
+        # ratio g = E_source / E_disc
+        e_src / e_disc
+    end
+end
+
 export LampPostModel

--- a/src/transfer-functions/cunningham-transfer-functions.jl
+++ b/src/transfer-functions/cunningham-transfer-functions.jl
@@ -1,22 +1,3 @@
-@with_kw struct CunninghamTransferFunction{T}
-    "``g^\\ast`` values."
-    g✶::Vector{T}
-    "Transfer function data."
-    f::Vector{T}
-    gmin::T
-    gmax::T
-    "Emission radius."
-    rₑ::T
-end
-
-@with_kw struct InterpolatedCunninghamTransferFunction{T,U,L}
-    upper_f::U
-    lower_f::L
-    gmin::T
-    gmax::T
-    rₑ::T
-end
-
 function _make_sorted_interpolation(g, f)
     I = sortperm(g)
     _g = @inbounds g[I]

--- a/src/transfer-functions/transfer-functions-2d.jl
+++ b/src/transfer-functions/transfer-functions-2d.jl
@@ -140,7 +140,7 @@ function lagtransfer(
     I = [i.status == StatusCodes.IntersectedWithGeometry for i in o_to_d]
     areas = unnormalized_areas(plane)[I]
 
-    LagTransferFunction(max_t, m, u, areas, s_to_d, o_to_d[I])
+    LagTransferFunction(max_t, m, model, u, areas, s_to_d, o_to_d[I])
 end
 
 function _interpolate_profile(tf::LagTransferFunction)

--- a/src/transfer-functions/transfer-functions-2d.jl
+++ b/src/transfer-functions/transfer-functions-2d.jl
@@ -86,26 +86,6 @@ function observer_to_disc(
     points
 end
 
-struct LagTransferFunction{T,M,U,P}
-    max_t::T
-    metric::M
-    u::U
-    image_plane_areas::Vector{T}
-    source_to_disc::Vector{P}
-    observer_to_disc::Vector{P}
-end
-
-function Base.show(io::IO, ::MIME"text/plain", tf::LagTransferFunction)
-    text = """LagTransferFunction for $(typeof(tf.metric)) 
-      . observer position      
-          $(tf.u)
-      . observer to disc photon count : $(length(tf.observer_to_disc))
-      . source to disc photon count   : $(length(tf.source_to_disc))
-      Total memory: $(Base.format_bytes(Base.summarysize(tf)))
-    """
-    print(io, text)
-end
-
 function lagtransfer(m::AbstractMetricParams, u, d::AbstractAccretionGeometry; kwargs...)
     model = LampPostModel(h = 10.0, θ = deg2rad(0.0001))
     plane = PolarPlane(GeometricGrid(); Nr = 800, Nθ = 800, r_max = 250.0)
@@ -121,8 +101,14 @@ function lagtransfer(
     max_t = 2 * u[2],
     n_samples = 10_000,
     sampler = EvenSampler(domain = BothHemispheres(), generator = RandomGenerator()),
+    verbose = false,
     solver_opts...,
 )
+    progress_bar = init_progress_bar(
+        "Source to disc:   ",
+        n_samples + trajectory_count(plane),
+        verbose,
+    )
     s_to_d = source_to_disc(
         m,
         model,
@@ -130,8 +116,14 @@ function lagtransfer(
         max_t;
         n_samples = n_samples,
         sampler = sampler,
+        verbose = verbose,
+        progress_bar = progress_bar,
         solver_opts...,
     )
+
+    if verbose
+        progress_bar.desc = "Observer to disc: "
+    end
     o_to_d = observer_to_disc(
         m,
         u,
@@ -139,6 +131,8 @@ function lagtransfer(
         d,
         max_t;
         chart = chart_for_metric(m, 1.1 * u[2]),
+        verbose = verbose,
+        progress_bar = progress_bar,
         solver_opts...,
     )
 
@@ -160,9 +154,9 @@ function binflux(
     redshift = ConstPointFunctions.redshift(tf.metric, tf.u),
     ε = (gp) -> gp.u2[2]^(-3),
     E₀ = 6.4,
+    profile = RadialDiscProfile(ε, tf),
     kwargs...,
 )
-    profile = RadialDiscProfile(ε, tf.source_to_disc)
     t, i_em = delay_flux(profile, tf.observer_to_disc)
     g = redshift.(tf.metric, tf.observer_to_disc, tf.max_t)
 

--- a/src/transfer-functions/types.jl
+++ b/src/transfer-functions/types.jl
@@ -17,9 +17,10 @@ struct InterpolatedCunninghamTransferFunction{T,U,L}
     rₑ::T
 end
 
-struct LagTransferFunction{T,M,U,P}
+struct LagTransferFunction{T,M,Q,U,P}
     max_t::T
     metric::M
+    model::Q
     u::U
     image_plane_areas::Vector{T}
     source_to_disc::Vector{P}
@@ -30,6 +31,7 @@ function Base.show(io::IO, ::MIME"text/plain", tf::LagTransferFunction)
     text = """LagTransferFunction for $(typeof(tf.metric)) 
       . observer position      
           $(tf.u)
+      . model                         : $(typeof(tf.model))
       . observer to disc photon count : $(length(tf.observer_to_disc))
       . source to disc photon count   : $(length(tf.source_to_disc))
       Total memory: $(Base.format_bytes(Base.summarysize(tf)))

--- a/src/transfer-functions/types.jl
+++ b/src/transfer-functions/types.jl
@@ -1,0 +1,38 @@
+struct CunninghamTransferFunction{T}
+    "``g^\\ast`` values."
+    g✶::Vector{T}
+    "Transfer function data."
+    f::Vector{T}
+    gmin::T
+    gmax::T
+    "Emission radius."
+    rₑ::T
+end
+
+struct InterpolatedCunninghamTransferFunction{T,U,L}
+    upper_f::U
+    lower_f::L
+    gmin::T
+    gmax::T
+    rₑ::T
+end
+
+struct LagTransferFunction{T,M,U,P}
+    max_t::T
+    metric::M
+    u::U
+    image_plane_areas::Vector{T}
+    source_to_disc::Vector{P}
+    observer_to_disc::Vector{P}
+end
+
+function Base.show(io::IO, ::MIME"text/plain", tf::LagTransferFunction)
+    text = """LagTransferFunction for $(typeof(tf.metric)) 
+      . observer position      
+          $(tf.u)
+      . observer to disc photon count : $(length(tf.observer_to_disc))
+      . source to disc photon count   : $(length(tf.source_to_disc))
+      Total memory: $(Base.format_bytes(Base.summarysize(tf)))
+    """
+    print(io, text)
+end


### PR DESCRIPTION
There's a mistake in the emissivity profile as it is currently being calculated; it should be

$$
\varepsilon(r) = \frac{N(r)}{g^2 A(r, \text{d}r)},
$$

but we currently are missing the divide by redshift, where here the redshift if for the disc element and X-ray source respectively

$$
g^{-1} = \frac{E_\text{disc}}{E_\text{source}}.
$$

This is a little annoying to implement as currently the lag transfer functions don't track the model, but they probably should.