### PR TITLE
Feat: Kerr-Newman metric

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.2.11"
+version = "0.2.12"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -143,6 +143,7 @@ abstract type AbstractDirectionSampler{SkyDomain,Generator} end
 include("utils.jl")
 
 include("tracing/tracing.jl")
+include("tracing/geodesic-problem.jl")
 include("tracing/constraints.jl")
 include("tracing/charts.jl")
 include("tracing/callbacks.jl")
@@ -191,6 +192,7 @@ include("metrics/morris-thorne-ad.jl")
 include("metrics/kerr-refractive-ad.jl")
 include("metrics/dilaton-axion-ad.jl")
 include("metrics/bumblebee-ad.jl")
+include("metrics/kerr-newman-ad.jl")
 
 include("special-radii.jl")
 include("redshift.jl")

--- a/src/metrics/kerr-newman-ad.jl
+++ b/src/metrics/kerr-newman-ad.jl
@@ -1,0 +1,94 @@
+module __KerrNewmanAD
+using ..StaticArrays
+using ..MuladdMacro
+
+@muladd @fastmath begin
+    rQ(Q) = Q^2 / (4 * π)
+    Σ(r, a, θ) = r^2 + (a * cos(θ))^2
+    Δ(r, R, a, Q) = r^2 - R * r + a^2 + rQ(Q)^2
+
+    # the way this function must be defined is a little complex
+    # but helps with type-stability
+    function metric_components(M, a, Q, rθ)
+        (r, θ) = rθ
+        R = 2M
+        Σ₀ = Σ(r, a, θ)
+        sinθ2 = sin(θ)^2
+
+        tt = -(1 - (R * r) / Σ₀)
+        rr = Σ₀ / Δ(r, R, a, Q)
+        θθ = Σ₀
+        ϕϕ = sinθ2 * (r^2 + a^2 + (sinθ2 * R * r * a^2) / Σ₀)
+
+        tϕ = (-R * r * a * sinθ2) / Σ₀
+        @SVector [tt, rr, θθ, ϕϕ, tϕ]
+    end
+
+    function electromagnetic_potential(m, rθ)
+        (r, θ) = rθ
+        Σ₀ = Σ(r, m.a, θ)
+        rq = rQ(m.Q)
+        SVector{4,eltype(rθ)}(r * rq / Σ₀, 0, 0, -m.a * r * rq * sin(θ)^2 / Σ₀)
+    end
+end
+
+end # module
+
+"""
+    struct KerrNewmanMetric{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+"""
+struct KerrNewmanMetric{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
+    "Black hole mass."
+    M::T
+    "Black hole spin."
+    a::T
+    "Black hole charge."
+    Q::T
+
+    function KerrNewmanMetric(M::T, a, Q) where {T}
+        if a^2 + Q^2 > M^2
+            error("Value error: `a^2 + Q^2` must be `<= M^2`")
+        end
+        new{T}(T(M), T(a), T(Q))
+    end
+end
+
+# implementation
+metric_components(m::KerrNewmanMetric{T}, rθ) where {T} =
+    __KerrNewmanAD.metric_components(m.M, m.a, m.Q, rθ)
+inner_radius(m::KerrNewmanMetric{T}) where {T} =
+    m.M + √(m.M^2 - m.a^2 - __KerrNewmanAD.rQ(m.Q)^2)
+
+electromagnetic_potential(m::KerrNewmanMetric, x) =
+    __KerrNewmanAD.electromagnetic_potential(m, x)
+
+function geodesic_ode_problem(
+    m::KerrNewmanMetric{T},
+    pos::StaticVector{S,T},
+    vel::StaticVector{S,T},
+    time_domain,
+    ;
+    q = 0.0,
+    kwargs...,
+) where {S,T}
+    function f(u::SVector{8,T}, p, λ) where {T}
+        @inbounds let x = SVector{4,T}(@view(u[1:4])), v = SVector{4,T}(@view(u[5:8]))
+            dv = SVector{4,T}(geodesic_eq(m, x, v))
+            # add maxwell part
+            F = maxwell_tensor(m, x)
+            dvf = q * (F * v)
+            vcat(v, dv + dvf)
+        end
+    end
+
+    u_init = vcat(pos, vel)
+    ODEProblem{false}(
+        f,
+        u_init,
+        time_domain,
+        IntegrationParameters(StatusCodes.NoStatus);
+        kwargs...,
+    )
+end
+
+export KerrNewmanMetric

--- a/src/metrics/kerr-newman-ad.jl
+++ b/src/metrics/kerr-newman-ad.jl
@@ -21,7 +21,7 @@ using ..MuladdMacro
         θθ = Σ₀
         ϕϕ = (sinθ2 / Σ₀) * (r2a2^2 - a^2 * sinθ2 * Δ₀)
 
-        tϕ = (2a * sinθ2 / Σ₀) * (Δ₀ - r2a2)
+        tϕ = (a * sinθ2 / Σ₀) * (Δ₀ - r2a2)
         @SVector [tt, rr, θθ, ϕϕ, tϕ]
     end
 

--- a/src/metrics/kerr-newman-ad.jl
+++ b/src/metrics/kerr-newman-ad.jl
@@ -53,6 +53,8 @@ struct KerrNewmanMetric{T} <: AbstractAutoDiffStaticAxisSymmetricParams{T}
     end
 end
 
+KerrNewmanMetric(; M = 1.0, a = 0.0, Q = 0.0) = KerrNewmanMetric(M, a, Q)
+
 # implementation
 metric_components(m::KerrNewmanMetric{T}, rθ) where {T} =
     __KerrNewmanAD.metric_components(m.M, m.a, m.Q, rθ)

--- a/src/metrics/kerr-newman-ad.jl
+++ b/src/metrics/kerr-newman-ad.jl
@@ -28,8 +28,7 @@ using ..MuladdMacro
     function electromagnetic_potential(m, rθ)
         (r, θ) = rθ
         Σ₀ = Σ(r, m.a, θ)
-        rq = rQ(m.Q)
-        SVector{4,eltype(rθ)}(r * rq / Σ₀, 0, 0, -m.a * r * rq * sin(θ)^2 / Σ₀)
+        SVector{4,eltype(rθ)}(r * m.Q / Σ₀, 0, 0, -m.a * r * m.Q * sin(θ)^2 / Σ₀)
     end
 end
 

--- a/src/special-radii.jl
+++ b/src/special-radii.jl
@@ -89,6 +89,7 @@ event_horizon(m::AbstractMetricParams; kwargs...) =
 function _event_horizon_condition(m, r, θ)
     g = metric_components(m, (r, θ))
     g[5]^2 - g[1] * g[4]
+    # inv(g[2])
 end
 
 function event_horizon(
@@ -102,10 +103,11 @@ function event_horizon(
     rs = map(θs) do θ
         f(r) = _event_horizon_condition(m, r, θ)
         r = Roots.find_zeros(f, 0.0, rmax)
-        if isempty(r)
-            push!(r, NaN)
+        if isempty(r) || all(isnan, r)
+            NaN
+        else
+            select(r)
         end
-        select(r)
     end
     rs, θs
 end

--- a/src/tracing/geodesic-problem.jl
+++ b/src/tracing/geodesic-problem.jl
@@ -1,0 +1,77 @@
+function geodesic_ode_problem(
+    m::AbstractMetricParams,
+    pos::StaticVector,
+    vel::StaticVector,
+    time_domain;
+    q = 0.0,
+    kwargs...,
+)
+    function f(u::SVector{8,T}, p, λ) where {T}
+        @inbounds let x = SVector{4,T}(@view(u[1:4])), v = SVector{4,T}(@view(u[5:8]))
+            dv = SVector{4,T}(geodesic_eq(m, x, v))
+            # SVector{8}(v[1], v[2], v[3], v[4], dv[1], dv[2], dv[3], dv[4])
+            vcat(v, dv)
+        end
+    end
+
+    u_init = vcat(pos, vel)
+    ODEProblem{false}(
+        f,
+        u_init,
+        time_domain,
+        IntegrationParameters(StatusCodes.NoStatus);
+        kwargs...,
+    )
+end
+
+function geodesic_problem(
+    m::AbstractMetricParams,
+    init_pos::U,
+    init_vel::V,
+    time_domain::NTuple{2},
+    ;
+    callback = nothing,
+    chart = chart_for_metric(m),
+    μ = 0.0,
+    kwargs...,
+) where {U,V}
+    # create the callback set for the problem
+    cbs = create_callback_set(m, callback, chart)
+    function _problem(x, v)
+        geodesic_ode_problem(m, x, v, time_domain; callback = cbs, kwargs...)
+    end
+    wrap_arguments(m, init_pos, init_vel, _problem, μ)
+end
+
+function wrap_arguments(
+    m::AbstractMetricParams,
+    init_pos::U,
+    init_vel::V,
+    _problem_func,
+    μ,
+) where {U,V}
+    if U <: SVector && V <: SVector
+        # single position and velocity
+        return _problem_func(init_pos, constrain_all(m, init_pos, init_vel, μ))
+    elseif U <: SVector && V <: Function
+        # single position, velocity generating function
+        _vfunc = wrap_constraint(m, init_pos, init_vel, μ)
+        prob = _problem_func(init_pos, _vfunc(1))
+        ens_prob = EnsembleProblem(
+            prob,
+            prob_func = (prob, i, repeat) -> _problem_func(init_pos, _vfunc(i)),
+            safetycopy = false,
+        )
+        return ens_prob
+    elseif U === V
+        # both are arrays of SVectors
+        _vels = constrain_all(m, init_pos, init_vel, μ)
+        prob = _problem_func(init_pos[1], _vels[1])
+        ens_prob = EnsembleProblem(
+            prob,
+            prob_func = (prob, i, repeat) -> _problem_func(init_pos[i], _vels[i]),
+            safetycopy = false,
+        )
+        return ens_prob
+    end
+end

--- a/src/tracing/method-implementations/auto-diff.jl
+++ b/src/tracing/method-implementations/auto-diff.jl
@@ -262,7 +262,10 @@ function metric_jacobian(m::AbstractAutoDiffStaticAxisSymmetricParams, rθ)
     f = x -> metric_components(m, x)
     T = typeof(ForwardDiff.Tag(f, eltype(rθ)))
     ydual = ForwardDiff.ForwardDiffStaticArraysExt.static_dual_eval(T, f, rθ)
-    ForwardDiff.value.(T, ydual), ForwardDiff.ForwardDiffStaticArraysExt.extract_jacobian(T, ydual, rθ)
+    (
+        ForwardDiff.value.(T, ydual),
+        ForwardDiff.ForwardDiffStaticArraysExt.extract_jacobian(T, ydual, rθ),
+    )
 end
 
 @inbounds function geodesic_eq(

--- a/src/tracing/method-implementations/first-order.jl
+++ b/src/tracing/method-implementations/first-order.jl
@@ -111,11 +111,12 @@ function update_integration_parameters!(
     p
 end
 
-function integrator_problem(
+function geodesic_ode_problem(
     m::AbstractFirstOrderMetricParams{T},
     pos::StaticVector{S,T},
     vel::StaticVector{S,T},
     time_domain;
+    q = 0.0,
     kwargs...,
 ) where {S,T}
     L, Q = calc_lq(m, pos, vel)

--- a/src/tracing/utility.jl
+++ b/src/tracing/utility.jl
@@ -1,3 +1,7 @@
+function split_options(::AbstractMetricParams, opts)
+    opts, (;)
+end
+
 """
     map_impact_parameters(m::AbstractMetricParams{T}, u, α, β)
 
@@ -24,6 +28,20 @@ end
 @inline function impact_parameters_to_vel(m::AbstractMetricParams{T}, u, α, β) where {T}
     mcomp = metric_components(m, @view(u[2:3]))
     T(-1.0), -β / mcomp[3], -α / √(mcomp[3] * mcomp[4])
+end
+
+function maxwell_tensor(m::AbstractMetricParams, x)
+    ST = SVector{4,eltype(x)}
+    dA = ForwardDiff.jacobian(t -> electromagnetic_potential(m, t), SVector(x[2], x[3]))
+    ∂A = hcat(zeros(ST), dA, zeros(ST))
+    g = inv(metric(m, x))
+    # raise first index: F^μ_κ
+
+    # @tullio F[μ, κ] := g[μ, σ] * (∂A[σ, κ] - ∂A[κ, σ])
+    # SMatrix(F)
+
+    # faster
+    g * (∂A - ∂A')
 end
 
 export map_impact_parameters

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ end
 
 @testset "metric-geometry" verbose = true begin
     include("unit/gradusbase.geometry.jl")
+    include("unit/metrics.kerr-newman.jl")
     include("test-special-radii.jl")
 end
 

--- a/test/smoke-tests/rendergeodesics.jl
+++ b/test/smoke-tests/rendergeodesics.jl
@@ -18,13 +18,21 @@ end
     u = @SVector [0.0, 100.0, deg2rad(85), 0.0]
 
     # last computed 21/01/2023: shrink resolution
-    expected = (8969.1564582409967, 8969.15634220181, 8977.502920124776, 413.4963434133726, 8969.155411207657)
+    expected = (
+        8969.1564582409967,
+        8969.15634220181,
+        8977.502920124776,
+        413.4963434133726,
+        8969.155411207657,
+        8969.157492589824,
+    )
     result = map((
         KerrMetric(),
         JohannsenMetric(),
         KerrSpacetimeFirstOrder(),
         MorrisThorneWormhole(),
         BumblebeeMetric(),
+        KerrNewmanMetric(),
     )) do m
         α, β, img = rendergeodesics(
             m,

--- a/test/smoke-tests/tracegeodesics.jl
+++ b/test/smoke-tests/tracegeodesics.jl
@@ -30,7 +30,8 @@ using StaticArrays
             JohannsenMetric(),
             KerrSpacetimeFirstOrder(),
             MorrisThorneWormhole(),
-            BumblebeeMetric()
+            BumblebeeMetric(),
+            KerrNewmanMetric(),
         ]
             test_single(m, u, v)
             test_many(m, u, v)

--- a/test/unit/metrics.kerr-newman.jl
+++ b/test/unit/metrics.kerr-newman.jl
@@ -1,0 +1,26 @@
+using Test
+using Gradus
+
+# test that tracing with charged test-particles actually
+# produces different results (/ is being executed correctly)
+m = KerrNewmanMetric(M = 1.0, a = 0.6, Q = 0.6)
+u = SVector(0.0, 1000.0, π / 2, 0.0)
+
+function test_tracer(m, u, q)
+    α, β, img = @time rendergeodesics(
+        m,
+        u,
+        # max integration time
+        2000.0,
+        image_width = 40,
+        image_height = 40,
+        fov = 2.5,
+        q = q,
+    )
+    fingerprint = sum(filter(!isnan, img))
+    fingerprint
+end
+
+@test test_tracer(m, u, 0.0) ≈ 450413.5565857728
+@test test_tracer(m, u, 1.0) ≈ 263050.89536876464
+@test test_tracer(m, u, -1.0) ≈ 652669.0871285137


### PR DESCRIPTION
The event horizon is not being correctly calculated for this metric yet, suggesting there is a typo somewhere but I can't seem to find it.

There's also the ambiguity between the EH being

$$
\left. \frac{1}{g_{rr}}\right \rvert_{r_\text{EH}} = 0,
$$

or the Killing horizon corresponding to the $\frac{\partial}{\partial t}$ and $\frac{\partial}{\partial \phi}$ Killing vectors, i.e.

$$
\left. \left( g_{t\phi}^2 - g_{tt} g_{\phi \phi} \right) \right\rvert_{r_\text{EH}} = 0.
$$

They should be the same. For the Kerr-Newman metric currently implemented, they are not when $|a|>0$.. so... that needs to be fixed.

Also missing tests.