### PR TITLE
fix: relativistic beaming

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gradus"
 uuid = "c5b7b928-ea15-451c-ad6f-a331a0f3e4b7"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.4.11"
+version = "0.4.12"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -29,5 +29,5 @@ Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 VoronoiCells = "e3e34ffb-84e9-5012-9490-92c94d0c60a4"
 
 [compat]
-julia = "1.9"
 Buckets = ">=0.1.10"
+julia = "1.9"

--- a/src/GradusBase/geometry.jl
+++ b/src/GradusBase/geometry.jl
@@ -48,18 +48,22 @@ function gramschmidt(v, basis, g; tol = 4eps(eltype(g)))
 end
 
 # TODO: this presupposes static and axis symmetric
+# this works for LNRF, but needs to work for e.g. ZAMO as well
+# which means we need to reorder the approach depending on the 
+# non-zero components of `v`
 @inline function tetradframe(g::AbstractMatrix{T}, v) where {T}
+    # normalise the vector to unit length
     vt = v ./ √abs(propernorm(g, v))
     # start procedure with ϕ, which has zero for r and θ
     vϕ = gramschmidt(SVector{4,T}(1, 0, 0, 1), (vt,), g)
     # then do r, which has zero for θ
-    vr = gramschmidt(SVector{4,T}(0, 1, 0, 0), (vt, vϕ), g)
+    vr = gramschmidt(SVector{4,T}(1, 1, 0, 1), (vt, vϕ), g)
     # then finally θ
-    vθ = gramschmidt(SVector{4,T}(0, 0, 1, 0), (vt, vϕ, vr), g)
+    vθ = gramschmidt(SVector{4,T}(1, 1, 1, 1), (vt, vϕ, vr), g)
     (vt, vr, vθ, vϕ)
 end
 
-tetradframe(m::AbstractMetric, u, v) = tetradframe(metric(m, u), v)
+tetradframe(m::AbstractMetric, x, v) = tetradframe(metric(m, x), v)
 
 # TODO: this presupposes static and axis symmetric
 # tetrad with latin indices down: frame

--- a/src/GradusBase/geometry.jl
+++ b/src/GradusBase/geometry.jl
@@ -47,25 +47,62 @@ function gramschmidt(v, basis, g; tol = 4eps(eltype(g)))
     v / vnorm
 end
 
-# TODO: this presupposes static and axis symmetric
-# this works for LNRF, but needs to work for e.g. ZAMO as well
-# which means we need to reorder the approach depending on the 
-# non-zero components of `v`
-@inline function tetradframe(g::AbstractMatrix{T}, v) where {T}
-    # normalise the vector to unit length
-    vt = v ./ √abs(propernorm(g, v))
-    # start procedure with ϕ, which has zero for r and θ
-    vϕ = gramschmidt(SVector{4,T}(1, 0, 0, 1), (vt,), g)
-    # then do r, which has zero for θ
-    vr = gramschmidt(SVector{4,T}(1, 1, 0, 1), (vt, vϕ), g)
-    # then finally θ
-    vθ = gramschmidt(SVector{4,T}(1, 1, 1, 1), (vt, vϕ, vr), g)
-    (vt, vr, vθ, vϕ)
-end
+"""
+    _tetrad_permute(x)
 
+Permute the spatial components (vectors) of a given tetrad. That is, given
+some `x = (e1, e2, e3, e4)`, a single call to `_tetrad_permute` will return
+`(e1, e4, e2, e3)`.
+
+Attempts to respect the input type in the return type. Checked for `SVector` and `NTuple`.
+"""
+_tetrad_permute(x::SVector{4,T}) where {T} = SVector{4,T}(x[1], x[4], x[2], x[3])
+_tetrad_permute(x::NTuple{4}) = (x[1], x[4], x[2], x[3])
+
+"""
+    tetradframe(m::AbstractMetric, x, v)
+    tetradframe(g::AbstractMatrix [= metric(m, x)], v)
+
+Compute a tetrad frame via the Gram-Schmidt orthonormalization procedure (see [`gramschmidt`](@ref)),
+where the first vector of the frame is the velocity vector `v` at some position `x`.
+
+Used to compute the locally non-rotating frame via [`lnrframe`](@ref) and [`lnrbasis`](@ref) 
+respectively.
+
+Attempts to reorder the tetrad into a canonical form associated with the global coordinates,
+that is, returns a tuple that corresponds to the ``x^1, x^2, x^3, x^4`` coordinates of the spacetime.
+"""
+@inline function tetradframe(g::AbstractMatrix{T}, v) where {T}
+    # TODO: this presupposes static and axis symmetric
+    # normalise the vector to unit length
+    v1 = v ./ √abs(propernorm(g, v))
+
+    state = v1 .!= 0
+    # ensure there is an initial direction
+    # else just set it to r
+    if sum(state) == 1
+        state = SVector{4,eltype(state)}(1, 0, 0, 1)
+    end
+    # store number of permutations of the space vectors needed to get 
+    # tetrad in the correct order at the end
+    permutations = searchsortedfirst(@views(state[2:end]), 1)
+    v2 = gramschmidt(SVector{4,T}(state), (v1,), g)
+
+    state = state .| _tetrad_permute(state)
+    v3 = gramschmidt(SVector{4,T}(state), (v1, v2), g)
+
+    state = state .| _tetrad_permute(state)
+    v4 = gramschmidt(SVector{4,T}(state), (v1, v2, v3), g)
+
+    # order and return t, r, θ, ϕ
+    ret = (v1, v2, v3, v4)
+    for _ = 2:permutations
+        ret = _tetrad_permute(ret)
+    end
+    ret
+end
 tetradframe(m::AbstractMetric, x, v) = tetradframe(metric(m, x), v)
 
-# TODO: this presupposes static and axis symmetric
 # tetrad with latin indices down: frame
 function lnrframe(g::AbstractMatrix{T}) where {T}
     ω = -g[1, 4] / g[4, 4]

--- a/src/corona/emissivity.jl
+++ b/src/corona/emissivity.jl
@@ -19,7 +19,7 @@ function source_to_disc_emissivity(m::AbstractStaticAxisSymmetric, 𝒩, A, x, g
     gcomp = metric_components(m, x)
     v = CircularOrbits.fourvelocity(m, x)
     # account for relativistic effects in area
-    γ = lorentz_factor(m, SVector(0, x[1], x[2], 0), v) 
+    γ = lorentz_factor(m, SVector(0, x[1], x[2], 0), v)
     A_corrected = A * √(gcomp[2] * gcomp[4])
     # divide by area to get number density
     𝒩 / (g^2 * A_corrected * γ)

--- a/src/corona/sky-geometry.jl
+++ b/src/corona/sky-geometry.jl
@@ -73,7 +73,8 @@ end
 
     J = _cart_to_spher_jacobian(u[3], u[4])
     k = J * hat
-    # v = constrain_all(m, u, SVector(0, k[1], k[2], k[3]), 0)
+    # todo: check whether this needs normalizing
+    # v = constrain_all(m, u, SVector(1, k[1], k[2], k[3]), μ)
     v = SVector(0, k[1], k[2], k[3])
 
     basis = tetradframe(m, u, v_source)

--- a/src/metrics/boyer-lindquist-ad.jl
+++ b/src/metrics/boyer-lindquist-ad.jl
@@ -65,9 +65,8 @@ $(FIELDS)
 end
 
 # implementation
-metric_components(m::KerrMetric{T}, rθ) where {T} =
-    __BoyerLindquistAD.metric_components(m.M, m.a, rθ)
-inner_radius(m::KerrMetric{T}) where {T} = m.M + √(m.M^2 - m.a^2)
+metric_components(m::KerrMetric, rθ) = __BoyerLindquistAD.metric_components(m.M, m.a, rθ)
+inner_radius(m::KerrMetric) = m.M + √(m.M^2 - m.a^2)
 
 # additional utilities
 function convert_angles(a, r, θ, ϕ, θ_obs, ϕ_obs)
@@ -81,11 +80,11 @@ function convert_angles(a, r, θ, ϕ, θ_obs, ϕ_obs)
 end
 
 # for disc profile models
-function GradusBase.vector_to_local_sky(m::KerrMetric{T}, u, θ, ϕ) where {T}
+function GradusBase.vector_to_local_sky(m::KerrMetric, u, θ, ϕ)
     convert_angles(m.a, u[2], u[3], u[4], θ, ϕ)
 end
 
 # special radii
-isco(m::KerrMetric{T}) where {T} = __BoyerLindquistFO.isco(m.M, m.a)
+isco(m::KerrMetric) = __BoyerLindquistFO.isco(m.M, m.a)
 
 export KerrMetric

--- a/src/tracing/utility.jl
+++ b/src/tracing/utility.jl
@@ -13,10 +13,10 @@ Note, assumes ``\\mu = 0``.
 function local_momentum(r_obs, α, β)
     b = β / r_obs
     a = α / r_obs
-    prpt = -inv(sqrt(1 + a^2 + b^2))
-    pθpt = b * prpt
-    pϕpt = a * prpt
-    SVector(1, prpt, pθpt, pϕpt)
+    pr_pt = -inv(sqrt(1 + a^2 + b^2))
+    pθ_pt = b * pr_pt
+    pϕ_pt = a * pr_pt
+    SVector(1, pr_pt, pθ_pt, pϕ_pt)
 end
 
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,10 @@ end
     include("test-special-radii.jl")
 end
 
+@time @testset "corona" verbose = true begin
+    include("unit/coronal-beaming.jl")
+end
+
 @time @testset "integration" verbose = true begin
     include("integration/test-inference.jl")
     include("integration/test-charts.jl")

--- a/test/unit/coronal-beaming.jl
+++ b/test/unit/coronal-beaming.jl
@@ -1,0 +1,61 @@
+using Test
+using Gradus
+using LinearAlgebra: diagm
+using Tullio
+
+# is the beaming being calculated correctly? 
+# using Eq. (10) in Gonzalez+17 for the analytic tetrad
+# NB: they use (+, -, -, -), whereas we use (-, +, +, +)
+
+drdt(g, β) = β * √(-g[1] / g[2])
+drdt(m::AbstractMetric, x, β) = drdt(metric_components(m, SVector(x[2], x[3])), β)
+
+# Eq. (8) in G+17
+drdt_analytic(r, a, β) = β * (r^2 - 2r + a^2) / (r^2 + a^2)
+
+function analytic_tetrad(m::AbstractMetric, x, β)
+    g = metric_components(m, SVector(x[2], x[3]))
+    v = drdt(g, β)
+
+    A = 1 / √(-g[1] - v^2 * g[2])
+    e_t = A * SVector(1, v, 0, 0)
+
+    B = √(-g[2] / g[1])
+    e_r = A * SVector(v * B, 1 / B, 0, 0)
+
+    e_θ = SVector(0, 0, √(1 / g[3]), 0)
+
+    C = 1 / √(-g[1] * (g[5]^2 - g[1] * g[4]))
+    e_ϕ = C * SVector(g[5], 0, 0, -g[1])
+
+
+    (e_t, e_r, e_θ, e_ϕ)
+end
+
+function is_minkowski(m, x, M)
+    m_mat = Gradus.metric(m, x)
+    @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
+    η = diagm([-1.0, 1.0, 1.0, 1.0])
+    @test res ≈ η
+end
+
+m = KerrMetric(1.0, 0.998)
+x = SVector(0, 3.0, deg2rad(0.01), 0)
+
+# make sure the velocity is correctly calculated
+@test drdt(m, x, 1) ≈ drdt_analytic(x[2], m.a, 1)
+
+M1 = analytic_tetrad(m, x, 0.25)
+# make sure analytic tetrad is approx minkowski
+is_minkowski(m, x, M1)
+
+v = SVector(1, drdt(m, x, 0.25), 0, 0)
+M2 = Gradus.tetradframe(m, x, v)
+# make sure our generic method is approx minkwoski
+is_minkowski(m, x, M2)
+
+mat1 = reduce(hcat, M1)
+mat2 = reduce(hcat, M2)
+
+# are they the same
+@test mat1 ≈ mat2

--- a/test/unit/gradusbase.geometry.jl
+++ b/test/unit/gradusbase.geometry.jl
@@ -31,7 +31,7 @@ for m in all_metrics, r in radii, θ in angles
     m_mat = Gradus.metric(m, u)
     @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
     # ensure it gives minkowski
-    @test isapprox(res, minkowski, atol = 1e-13)
+    @test res ≈ minkowski atol = 1e-13
 end
 
 for m in all_metrics, r in radii, θ in angles
@@ -43,7 +43,7 @@ for m in all_metrics, r in radii, θ in angles
     m_mat = Gradus.metric(m, u)
     @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
     # ensure it gives minkowski
-    @test isapprox(res, minkowski, atol = 1e-13)
+    @test res ≈ minkowski atol = 1e-13
 end
 
 # these test explicity check the LNRF calculations for the known
@@ -77,7 +77,7 @@ for M = 0.2:0.8:2.0, a = -M:0.5:M
         expected = kerr_lnrframe(m, u)
         calculated = numerical_lnrframe(m, u)
 
-        @test isapprox(calculated, expected, atol = 1e-13)
+        @test calculated ≈ expected atol = 1e-13
     end
 end
 
@@ -109,6 +109,6 @@ for M = 0.2:0.8:2.0, a = -M:0.5:M
         expected = kerr_lnrbasis(m, u)
         calculated = numerical_lnrbasis(m, u)
 
-        @test isapprox(calculated, expected, atol = 1e-10)
+        @test calculated ≈ expected atol = 1e-10
     end
 end

--- a/test/unit/gradusbase.geometry.jl
+++ b/test/unit/gradusbase.geometry.jl
@@ -3,120 +3,112 @@ using Gradus
 using StaticArrays
 using Tullio
 
-@testset "tetradframe" begin
-    all_metrics = (
-        # can't do first order yet since no four velocity
-        # KerrSpacetimeFirstOrder(1.0, 0.998, 1.0),
-        # KerrSpacetimeFirstOrder(1.0, -0.998, 1.0),
-        KerrMetric(1.0, 0.998),
-        KerrMetric(1.0, -0.998),
-        JohannsenMetric(M = 1.0, a = 0.998, α13 = 1.0),
-        JohannsenMetric(M = 1.0, a = 0.998, α22 = 1.0),
-        # DilatonAxion(M = 1.0, a = 0.998, β = 0.2, b = 1.0),
-    )
-    radii = 5.0:0.8:10.0
-    angles = 0.1:0.5:π
-    minkowski = @SMatrix [
-        -1.0 0.0 0.0 0.0
-        0.0 1.0 0.0 0.0
-        0.0 0.0 1.0 0.0
-        0.0 0.0 0.0 1.0
-    ]
-    for m in all_metrics, r in radii, θ in angles
-        u = @SVector([0.0, r, θ, 0.0])
-        v = Gradus.constrain_all(m, u, CircularOrbits.fourvelocity(m, r), 1.0)
+all_metrics = (
+    # can't do first order yet since no four velocity
+    # KerrSpacetimeFirstOrder(1.0, 0.998, 1.0),
+    # KerrSpacetimeFirstOrder(1.0, -0.998, 1.0),
+    KerrMetric(1.0, 0.998),
+    KerrMetric(1.0, -0.998),
+    JohannsenMetric(M = 1.0, a = 0.998, α13 = 1.0),
+    JohannsenMetric(M = 1.0, a = 0.998, α22 = 1.0),
+    # DilatonAxion(M = 1.0, a = 0.998, β = 0.2, b = 1.0),
+)
+radii = 5.0:0.8:10.0
+angles = 0.1:0.5:π
+minkowski = @SMatrix [
+    -1.0 0.0 0.0 0.0
+    0.0 1.0 0.0 0.0
+    0.0 0.0 1.0 0.0
+    0.0 0.0 0.0 1.0
+]
+for m in all_metrics, r in radii, θ in angles
+    u = @SVector([0.0, r, θ, 0.0])
+    v = Gradus.constrain_all(m, u, CircularOrbits.fourvelocity(m, r), 1.0)
 
-        # function that we are testing
-        M = Gradus.GradusBase.tetradframe(m, u, v)
+    # function that we are testing
+    M = Gradus.GradusBase.tetradframe(m, u, v)
 
-        m_mat = Gradus.metric(m, u)
-        @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
-        # ensure it gives minkowski
-        @test isapprox(res, minkowski, atol = 1e-13)
+    m_mat = Gradus.metric(m, u)
+    @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
+    # ensure it gives minkowski
+    @test isapprox(res, minkowski, atol = 1e-13)
+end
+
+for m in all_metrics, r in radii, θ in angles
+    u = @SVector([0.0, r, θ, 0.0])
+
+    # function that we are testing
+    M = Gradus.GradusBase.lnrframe(m, u)
+
+    m_mat = Gradus.metric(m, u)
+    @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
+    # ensure it gives minkowski
+    @test isapprox(res, minkowski, atol = 1e-13)
+end
+
+# these test explicity check the LNRF calculations for the known
+# theory of the Kerr metric
+
+function kerr_lnrframe(m, u)
+    A = Gradus.__BoyerLindquistFO.A(m.M, u[2], m.a, u[3])
+    Σ = Gradus.__BoyerLindquistFO.Σ(u[2], m.a, u[3])
+    Δ = Gradus.__BoyerLindquistFO.Δ(m.M, u[2], m.a)
+    ω = 2 * m.M * m.a * u[2] / A
+
+    et = √(A / (Σ * Δ)) * @SVector [1.0, 0.0, 0.0, ω]
+    er = √(Δ / Σ) * @SVector [0.0, 1.0, 0.0, 0.0]
+    eθ = √(1 / Σ) * @SVector [0.0, 0.0, 1.0, 0.0]
+    eϕ = √(Σ / A) * (1 / sin(u[3])) * @SVector [0.0, 0.0, 0.0, 1.0]
+
+    vecs = (et, er, eθ, eϕ)
+    reduce(hcat, vecs)
+end
+
+function numerical_lnrframe(m, u)
+    vecs = Gradus.GradusBase.lnrframe(m, u)
+    reduce(hcat, vecs)
+end
+
+for M = 0.2:0.8:2.0, a = -M:0.5:M
+    m = KerrMetric(M, a)
+    r = inner_radius(m) + 4.2
+    for θ in angles
+        u = @SVector [0.0, r, θ, 0.0]
+        expected = kerr_lnrframe(m, u)
+        calculated = numerical_lnrframe(m, u)
+
+        @test isapprox(calculated, expected, atol = 1e-13)
     end
+end
 
-    @testset "lnrf" begin
-        for m in all_metrics, r in radii, θ in angles
-            u = @SVector([0.0, r, θ, 0.0])
+function kerr_lnrbasis(m, u)
+    A = Gradus.__BoyerLindquistFO.A(m.M, u[2], m.a, u[3])
+    Σ = Gradus.__BoyerLindquistFO.Σ(u[2], m.a, u[3])
+    Δ = Gradus.__BoyerLindquistFO.Δ(m.M, u[2], m.a)
+    ω = 2 * m.M * m.a * u[2] / A
 
-            # function that we are testing
-            M = Gradus.GradusBase.lnrframe(m, u)
+    et = √(Σ * Δ / A) * @SVector [1.0, 0.0, 0.0, 0.0]
+    er = √(Σ / Δ) * @SVector [0.0, 1.0, 0.0, 0.0]
+    eθ = √Σ * @SVector [0.0, 0.0, 1.0, 0.0]
+    eϕ = √(A / Σ) * sin(u[3]) * @SVector [-ω, 0.0, 0.0, 1.0]
 
-            m_mat = Gradus.metric(m, u)
-            @tullio res[a, b] := m_mat[i, j] * M[a][i] * M[b][j]
-            # ensure it gives minkowski
-            @test isapprox(res, minkowski, atol = 1e-13)
-        end
-    end
+    vecs = (et, er, eθ, eϕ)
+    reduce(hcat, vecs)
+end
 
-    @testset "kerr-lnrf" begin
-        # these test explicity check the LNRF calculations for the known
-        # theory of the Kerr metric
+function numerical_lnrbasis(m, u)
+    vecs = Gradus.GradusBase.lnrbasis(m, u)
+    reduce(hcat, vecs)
+end
 
-        function kerr_lnrframe(m, u)
-            A = Gradus.__BoyerLindquistFO.A(m.M, u[2], m.a, u[3])
-            Σ = Gradus.__BoyerLindquistFO.Σ(u[2], m.a, u[3])
-            Δ = Gradus.__BoyerLindquistFO.Δ(m.M, u[2], m.a)
-            ω = 2 * m.M * m.a * u[2] / A
+for M = 0.2:0.8:2.0, a = -M:0.5:M
+    m = KerrMetric(M, a)
+    r = inner_radius(m) + 0.3
+    for θ in angles
+        u = @SVector [0.0, r, θ, 0.1]
+        expected = kerr_lnrbasis(m, u)
+        calculated = numerical_lnrbasis(m, u)
 
-            et = √(A / (Σ * Δ)) * @SVector [1.0, 0.0, 0.0, ω]
-            er = √(Δ / Σ) * @SVector [0.0, 1.0, 0.0, 0.0]
-            eθ = √(1 / Σ) * @SVector [0.0, 0.0, 1.0, 0.0]
-            eϕ = √(Σ / A) * (1 / sin(u[3])) * @SVector [0.0, 0.0, 0.0, 1.0]
-
-            vecs = (et, er, eθ, eϕ)
-            reduce(hcat, vecs)
-        end
-
-        function numerical_lnrframe(m, u)
-            vecs = Gradus.GradusBase.lnrframe(m, u)
-            reduce(hcat, vecs)
-        end
-
-        for M = 0.2:0.8:2.0, a = -M:0.5:M
-            m = KerrMetric(M, a)
-            r = inner_radius(m) + 4.2
-            for θ in angles
-                u = @SVector [0.0, r, θ, 0.0]
-                expected = kerr_lnrframe(m, u)
-                calculated = numerical_lnrframe(m, u)
-
-                @test isapprox(calculated, expected, atol = 1e-13)
-            end
-        end
-    end
-
-    @testset "kerr-lnrf-basis" begin
-        function kerr_lnrbasis(m, u)
-            A = Gradus.__BoyerLindquistFO.A(m.M, u[2], m.a, u[3])
-            Σ = Gradus.__BoyerLindquistFO.Σ(u[2], m.a, u[3])
-            Δ = Gradus.__BoyerLindquistFO.Δ(m.M, u[2], m.a)
-            ω = 2 * m.M * m.a * u[2] / A
-
-            et = √(Σ * Δ / A) * @SVector [1.0, 0.0, 0.0, 0.0]
-            er = √(Σ / Δ) * @SVector [0.0, 1.0, 0.0, 0.0]
-            eθ = √Σ * @SVector [0.0, 0.0, 1.0, 0.0]
-            eϕ = √(A / Σ) * sin(u[3]) * @SVector [-ω, 0.0, 0.0, 1.0]
-
-            vecs = (et, er, eθ, eϕ)
-            reduce(hcat, vecs)
-        end
-
-        function numerical_lnrbasis(m, u)
-            vecs = Gradus.GradusBase.lnrbasis(m, u)
-            reduce(hcat, vecs)
-        end
-
-        for M = 0.2:0.8:2.0, a = -M:0.5:M
-            m = KerrMetric(M, a)
-            r = inner_radius(m) + 0.3
-            for θ in angles
-                u = @SVector [0.0, r, θ, 0.1]
-                expected = kerr_lnrbasis(m, u)
-                calculated = numerical_lnrbasis(m, u)
-
-                @test isapprox(calculated, expected, atol = 1e-10)
-            end
-        end
+        @test isapprox(calculated, expected, atol = 1e-10)
     end
 end


### PR DESCRIPTION
Once the tests are all passing, this will be good to merge.

### Explanation

A tetrad is effectively a way of defining a locally flat coordinate system. The tetrad allows one to construct a series of orthonormal local basis vectors

$$
\frac{\partial}{\partial x^\mu} = e_\mu^{(i)},
$$

and a corresponding frame

$$
dx^\mu = e^\mu_{(i)},
$$

that translate vectors from global to local coordinates, and vice versa. Note that the index of the "local" picture is here in parenthesis and using latin characters -- this is just a convention to differentiate which is the local and which the global coordinate. $\mu$ expresses Boyer-Lindquist components $t, r, \theta, \phi$, whereas $i$ is a simple counter $0, 1, 2, 3$, for which we make an association to the BL components to motivate an interpretation (e.g. $0$ always points along the direction of the velocity in the global coordinates). Since the bases are orthonormal, we have $e^{(i)}\_{\mu} e\_{(j)}^\mu = \delta^{(i)}\_{(j)}$ (the [Kronecker delta](https://en.wikipedia.org/wiki/Kronecker_delta)). 

As a trivial example, for a stationary observer in flat space, a possible tetrad _is_ just the regular global coordinates, since global flatness here guaruntees local flatness. If the observer is in motion along say the $x$ axis, the local tetrad would have the $dt$ and $dx$ directions contracted as in regular [Minkowski diagrams](https://en.wikipedia.org/wiki/Spacetime_diagram). If the space is curved, imagine zooming into a local manifold (patch) of the curved space, where things appear flat, and constructing your tetrad there.

This flatness can be characterised by their relationship with the Minkowski tensor,

$$
\eta_{(ij)} = e\_{(i)} e\_{(j)} \left( = g\_{\mu \nu} e\_{(i)}^{\mu} e\_{(j)}^{\nu}  \right).
$$

Vectors decomposed over the tetrad basis can be treated as existing in regular special relativity.

The local space being flat means we can easily express quantities locally, and then transform them back to the global coordinates.

Constructing a general tetrad is ill-posed, since for a given initial vector, there are uncountably many orthogonal vectors that you can define -- so one usually tries to make associations with global coordinates, so that there is some sort of intuition to be held onto. The theorem of [Gram & Schmidt](https://en.wikipedia.org/wiki/Gram%E2%80%93Schmidt_process) ensures that it is always possible to construct an orthonormal basis from a given vector, and gives us enough freedom to make associations between directions (the theorem will also provide the mechanism by which we construct orthonormal frames).

### ZAMO and LNRF

The zero angular momentum (ZAMO) and locally non-rotating frame (LNRF) are two popular choices for building tetrads when studying static, axisymmetric spacetimes. In particular the LNRF has a very nice intuitive picture for the Kerr metric, namely within the ergo-sphere, the spacetime makes it impossible to continue on a trajectory with $v^\phi = 0$: the LNRF is therefore a frame which allows you to express $v^{(\phi)} = 0$, by having the coordinates move with the pull of the spacetime (the so-called [frame dragging effect](https://en.wikipedia.org/wiki/Frame-dragging)).

The ZAMO is another useful specification, in which your local angular momentum is always zero.

The LNRF is constructed by considering the angular velocity due to the pull of the spacetime $\omega = g\_{\phi\phi} / g\_{tt}$, and then finding vectors that are orthonormal to the "velocity of the frame"

$$
v^\mu = A \left(1, 0, 0, \omega \right),
$$

where $A$ is the normalisation. This is the first basis vector of our tetrad, $e^\mu\_{(0)}$.

To find the next orthogonal vector, we project a new vector, say $k^\mu = (1, 0, 0, 1)$, onto $e^\mu\_{(0)}$ and then subtract the projection from $k^\nu$, repeating until the projection vanishes. After normalisation, this is our $e^\mu\_{(1)}$ basis vector. By choosing $dr = d\theta = 0$ as our initial "guess", we obtain a vector which points somewhere between the global $dt$ and $d\phi$ axes, depending on $\omega$.

Next, we want to find a vector that we can associate with the $dr$ and $d\phi$ directions. Starting with the prior, we repeat the proceedure of subtraction projections (now onto both $e^\mu\_{(0)}$ and $e^\mu\_{(1)}$) for a new vector $k^\mu = (1, 1, 0, 1)$, which is guarunteed to not point along the $d\theta$ direction, since the projection in that direction is always zero.

For the LNRF, we actually obtain a basis vector $e^\mu\_{(2)} = (0, e^r\_{(2)}, 0, 0)$.

To find the last orthogonal vector, we take $k^\mu = (1, 1, 1, 1)$, and project it onto all basis vectors so far, and repeat the process anew. For LNRF, we obtain some $e^\mu\_{(3)} = (0, 0, e^\theta\_{(3)}, 0)$.

### The problem

The code currently does this all fine, but it is always using the same specific $k^\mu$ in the orthogonalization procedure. Compare this to e.g. the ZAMO for a source with velocity $v^\mu = A (1, v^r, 0, 0)$, where using the initial guess $k^\mu = (1, 0, 0, 1)$ will always yield an orthogonal vector with a $t$ and $\phi$ component, even though frame is not moving in $phi$. It would be more sensible, indeed more useful, to instead prime $k^\mu = (1, 1, 0, 0)$, and then proceed as usual to find the other directions.

Furthermore, it is convention that the tetrad frame is returned in such a way that $0$ is ("loosely") associated with the forward velocity ($t$), $1$ with the radial direction ($r$), etc., which means the function needs to also reorder the vectors so that they can be used in a regular sense.

### A sketch of the solution

The `tetradframe` function needs to be modified to be sensitive to which non-zero components are present in the initial velocity vector, and modify the $k^\mu$ to account for these.

For example:
- $v^\mu = A (1, 0, 0, v^\phi)$ needs to start with $k^\mu = (1, 0, 0, 1)$,
- $v^\mu = A (1, v^r, 0, 0)$ needs to start with $k^\mu = (1, 1, 0, 0)$,
- $v^\mu = A (1, v^r, v^\theta)$ needs to start with $k^\mu = (1, 1, 1, 0)$.

Furthmore, the function needs to then provide good $k^\mu$ for the remaining basis vectors, and then return them in a sensible $t, r, \theta, \phi$ order (if possible).
