### PR TITLE
Add GPU support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,12 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 VoronoiCells = "e3e34ffb-84e9-5012-9490-92c94d0c60a4"
 
+[weakdeps]
+DiffEqGPU = "071ae1c0-96b5-11e9-1965-c90190d839ea"
+
+[extensions]
+GradusDiffEqGPUExt = "DiffEqGPU"
+
 [compat]
 Buckets = ">=0.1.11"
 julia = "1.9"

--- a/docs/code/examples.jl
+++ b/docs/code/examples.jl
@@ -72,7 +72,7 @@ d = GeometricThinDisc(1.0, 50.0, deg2rad(90))
 
 # define point function which filters geodesics that intersected the accretion disc
 # and use those to calculate redshift
-pf = ConstPointFunctions.redshift(m, u) ∘ ConstPointFunctions.filter_intersected
+pf = ConstPointFunctions.redshift(m, u) ∘ ConstPointFunctions.filter_intersected()
 
 α, β, img = rendergeodesics(
     m,
@@ -211,7 +211,7 @@ pl_int = interpolate_plunging_velocities(m)
 
 redshift = interpolate_redshift(pl_int, x)
 
-pf = redshift ∘ ConstPointFunctions.filter_intersected
+pf = redshift ∘ ConstPointFunctions.filter_intersected()
 
 α, β, img = rendergeodesics(
     m,

--- a/docs/code/getting-started.jl
+++ b/docs/code/getting-started.jl
@@ -147,7 +147,7 @@ d = ThickDisc(x -> cross_section(x[2]))
 
 # ---------------------------------------------------------
 
-pf_geometry = time_coord ∘ ConstPointFunctions.filter_intersected
+pf_geometry = time_coord ∘ ConstPointFunctions.filter_intersected()
 
 # ---------------------------------------------------------
 
@@ -177,7 +177,7 @@ savefig(DIRR * "getting-started-6-weird-disc-render.png")
 
 redshift = ConstPointFunctions.redshift(m, x)
 # compose to filter those that intersected with the geometry
-redshift_geometry = redshift ∘ ConstPointFunctions.filter_intersected
+redshift_geometry = redshift ∘ ConstPointFunctions.filter_intersected()
 
 # ---------------------------------------------------------
 
@@ -204,7 +204,7 @@ is_naked_singularity(j_m)
 
 # pass the new metric
 j_redshift = ConstPointFunctions.redshift(j_m, x)
-j_redshift_geometry = j_redshift ∘ ConstPointFunctions.filter_intersected
+j_redshift_geometry = j_redshift ∘ ConstPointFunctions.filter_intersected()
 
 α, β, image = rendergeodesics(
     # pass the new metric

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -108,7 +108,7 @@ d = GeometricThinDisc(1.0, 50.0, deg2rad(90))
 
 # define point function which filters geodesics that intersected the accretion disc
 # and use those to calculate redshift
-pf = ConstPointFunctions.redshift(m, u) ∘ ConstPointFunctions.filter_intersected
+pf = ConstPointFunctions.redshift(m, u) ∘ ConstPointFunctions.filter_intersected()
 
 α, β, img = rendergeodesics(
     m,
@@ -281,7 +281,7 @@ pl_int = interpolate_plunging_velocities(m)
 
 redshift = interpolate_redshift(pl_int, x)
 
-pf = redshift ∘ ConstPointFunctions.filter_intersected
+pf = redshift ∘ ConstPointFunctions.filter_intersected()
 
 α, β, img = rendergeodesics(
     m,

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -317,7 +317,7 @@ The thick disc callback receives the full four-position, so we forward only the 
 We now need to update our point function so that it filters those geodesics which intersected with the geometry instead of those that fell into the black hole. This is a standard function already implemented in [`ConstPointFunctions`](@ref); only a composition is needed:
 
 ```julia
-pf_geometry = time_coord ∘ ConstPointFunctions.filter_intersected
+pf_geometry = time_coord ∘ ConstPointFunctions.filter_intersected()
 ```
 
 We then make a handful of small changes to make our image more interesting, and render just as before, passing the disc in to the [`rendergeodesics`](@ref) function:
@@ -362,7 +362,7 @@ We can choose any velocity profile we like, but for simplicity we use the veloci
 ```julia
 redshift = ConstPointFunctions.redshift(m, x)
 # compose to filter those that intersected with the geometry
-redshift_geometry = redshift ∘ ConstPointFunctions.filter_intersected
+redshift_geometry = redshift ∘ ConstPointFunctions.filter_intersected()
 ```
 
 This is another [`PointFunction`](@ref), and is used in the same way. Rendering as before:
@@ -395,7 +395,7 @@ j_m = JohannsenMetric(M=1.0, a = 0.7, α13 = 2.0, ϵ3 = 1.0)
 
 # pass the new metric
 j_redshift = ConstPointFunctions.redshift(j_m, x)
-j_redshift_geometry = j_redshift ∘ ConstPointFunctions.filter_intersected
+j_redshift_geometry = j_redshift ∘ ConstPointFunctions.filter_intersected()
 
 α, β, image = rendergeodesics(
     # pass the new metric

--- a/ext/GradusDiffEqGPUExt/GradusDiffEqGPUExt.jl
+++ b/ext/GradusDiffEqGPUExt/GradusDiffEqGPUExt.jl
@@ -1,0 +1,33 @@
+module GradusDiffEqGPUExt
+
+using Gradus
+using Gradus: EnsembleProblem, TracingConfiguration, solve
+
+using DiffEqGPU
+
+const EnsembleGPU = Union{<:EnsembleGPUArray,<:EnsembleGPUKernel}
+
+function Gradus.ensemble_solve_tracing_problem(
+    ensemble::EnsembleGPU,
+    problem::EnsembleProblem,
+    config::TracingConfiguration;
+    progress_bar = nothing,
+    save_on = false, # capture to avoid passing
+    solver_opts...,
+)
+    if !isnothing(progress_bar)
+        @warn "Progress meter is currently not supported for GPU ensemble algorithms."
+    end
+    solve(
+        problem,
+        config.solver,
+        ensemble,
+        ;
+        trajectories = config.trajectories,
+        abstol = config.abstol,
+        reltol = config.reltol,
+        solver_opts...,
+    )
+end
+
+end # module

--- a/src/Gradus.jl
+++ b/src/Gradus.jl
@@ -24,6 +24,17 @@ using MuladdMacro
 using Tullio: @tullio
 
 import ForwardDiff
+# todo: temporary fix for https://github.com/JuliaGPU/Metal.jl/issues/229
+function Base.sin(x::ForwardDiff.Dual{<:ForwardDiff.Tag{F,Float32}}) where {F}
+    s = sin(ForwardDiff.value(x))
+    c = cos(ForwardDiff.value(x))
+    return ForwardDiff.Dual{typeof(x).parameters[1]}(s, c * ForwardDiff.partials(x))
+end
+function Base.cos(x::ForwardDiff.Dual{<:ForwardDiff.Tag{F,Float32}}) where {F}
+    s = sin(ForwardDiff.value(x))
+    c = cos(ForwardDiff.value(x))
+    return ForwardDiff.Dual{typeof(x).parameters[1]}(c, -s * ForwardDiff.partials(x))
+end
 import GeometryBasics
 import Symbolics
 

--- a/src/const-point-functions.jl
+++ b/src/const-point-functions.jl
@@ -23,8 +23,9 @@ import ..Gradus
 A [`FilterPointFunction`](@ref) that filters geodesics that termined early (i.e., did not reach maximum integration time or effective infinity).
 Default: `NaN`.
 """
-const filter_early_term =
-    FilterPointFunction((m, gp, max_time; kwargs...) -> gp.λ_max < max_time, NaN)
+function filter_early_term(T::Type = Float64)
+    FilterPointFunction((m, gp, max_time; kwargs...) -> gp.λ_max < max_time, T(NaN))
+end
 
 """
     filter_intersected(m::AbstractMetric, gp::AbstractGeodesicPoint, max_time)
@@ -32,17 +33,21 @@ const filter_early_term =
 A [`FilterPointFunction`](@ref) that filters geodesics which intersected with the accretion
 disc. Default: `NaN`.
 """
-const filter_intersected = FilterPointFunction(
-    (m, gp, max_time; kwargs...) -> gp.status == StatusCodes.IntersectedWithGeometry,
-    NaN,
-)
+function filter_intersected(T::Type = Float64)
+    FilterPointFunction(
+        (m, gp, max_time; kwargs...) -> gp.status == StatusCodes.IntersectedWithGeometry,
+        T(NaN),
+    )
+end
 
 """
     affine_time(m::AbstractMetric, gp::AbstractGeodesicPoint, max_time)
 
 A [`PointFunction`](@ref) returning the affine integration time at the endpoint of the geodesic.
 """
-const affine_time = PointFunction((m, gp, max_time; kwargs...) -> gp.λ_max)
+function affine_time()
+    PointFunction((m, gp, max_time; kwargs...) -> gp.λ_max)
+end
 
 """
     shadow(m::AbstractMetric, gp::AbstractGeodesicPoint, max_time)
@@ -50,7 +55,9 @@ const affine_time = PointFunction((m, gp, max_time; kwargs...) -> gp.λ_max)
 A [`PointFunction`](@ref) which colours the shadow of the black hole for any disc-less render.
 Equivalent to `ConstPointFunctions.affine_time ∘ ConstPointFunctions.filter_early_term`.
 """
-const shadow = affine_time ∘ filter_early_term
+function shadow(T::Type = Float64)
+    affine_time() ∘ filter_early_term(T)
+end
 
 """
     redshift(m::AbstractMetric)

--- a/src/point-functions.jl
+++ b/src/point-functions.jl
@@ -78,9 +78,6 @@ struct FilterPointFunction{F,T} <: AbstractPointFunction
     default::T
 end
 
-# todo: this should type specialize better
-FilterPointFunction(f) = FilterPointFunction(f, NaN)
-
 @inline function (pf::AbstractPointFunction)(
     m::AbstractMetric,
     gp::AbstractGeodesicPoint{T},

--- a/src/rendering/rendering.jl
+++ b/src/rendering/rendering.jl
@@ -1,15 +1,15 @@
 function render_configuration(
-    m,
+    m::AbstractMetric{T},
     position,
     args...;
     image_width,
     image_height,
     fov,
-    μ = 0.0,
-    q = 0.0,
+    μ = T(0.0),
+    q = T(0.0),
     trace = TraceGeodesic(; μ = μ, q = q),
     kwargs...,
-)
+) where {T}
     config, solver_opts = tracing_configuration(
         trace,
         m,
@@ -30,7 +30,7 @@ function rendergeodesics(
     args...;
     image_width = 350,
     image_height = 250,
-    fov = 30.0,
+    fov = T(30.0),
     ensemble = EnsembleEndpointThreads(),
     kwargs...,
 ) where {T}
@@ -51,15 +51,15 @@ function rendergeodesics(
 end
 
 function prerendergeodesics(
-    m::AbstractMetric,
+    m::AbstractMetric{T},
     position,
     args...;
     cache = EndpointCache(),
     image_width = 350,
     image_height = 250,
-    fov = 3.0,
+    fov = T(3.0),
     kwargs...,
-)
+) where {T}
     trace, config, solver_opts = render_configuration(
         m,
         position,
@@ -82,11 +82,11 @@ end
 function render_into_image!(
     image,
     trace::AbstractTrace,
-    config::TracingConfiguration;
+    config::TracingConfiguration{T};
     pf = PointFunction((m, gp, λ_max) -> gp.λ_max) ∘
-         FilterPointFunction((m, gp, λ_max; kwargs...) -> gp.λ_max < λ_max, NaN),
+         FilterPointFunction((m, gp, λ_max; kwargs...) -> gp.λ_max < λ_max, T(NaN)),
     solver_opts...,
-)
+) where {T}
     sol_or_points = __render_geodesics(trace, config; solver_opts...)
     points = sol_or_points_to_points(sol_or_points)
     apply_to_image!(config.metric, image, points, pf, config.λ_domain[2])
@@ -143,8 +143,8 @@ function _render_velocity_function(
     function velfunc(i)
         Y = i % image_height
         X = i ÷ image_height
-        α = x_to_α(T, X, x_mid, fov)
-        β = y_to_β(T, Y, y_mid, fov)
+        α = x_to_α(X, x_mid, T(fov))
+        β = y_to_β(Y, y_mid, T(fov))
         xfm(local_momentum(position[2], α, β))
     end
 end

--- a/src/rendering/rendering.jl
+++ b/src/rendering/rendering.jl
@@ -131,20 +131,20 @@ function __prerendergeodesics(
 end
 
 function _render_velocity_function(
-    m::AbstractMetric,
+    m::AbstractMetric{T},
     position,
     image_width,
     image_height,
     fov,
-)
+) where {T}
     y_mid = image_height ÷ 2
     x_mid = image_width ÷ 2
     xfm = lnr_momentum_to_global_velocity_transform(m, position)
     function velfunc(i)
         Y = i % image_height
         X = i ÷ image_height
-        α = x_to_α(X, x_mid, fov)
-        β = y_to_β(Y, y_mid, fov)
+        α = x_to_α(T, X, x_mid, fov)
+        β = y_to_β(T, Y, y_mid, fov)
         xfm(local_momentum(position[2], α, β))
     end
 end

--- a/src/rendering/utility.jl
+++ b/src/rendering/utility.jl
@@ -35,7 +35,8 @@ Utility function for converting some `X` on an image plane into ``\\alpha``, giv
 the midpoint `x_mid` and field-of-view multiplier `fov`.
 """
 # have to use a slight 0.001 offset to avoid integrating α=0.0 geodesics in first order methods
-x_to_α(X, x_mid, fov) = (X + 1e-3 - x_mid) / fov
+x_to_α(X, x_mid, fov) = x_to_α(typeof(fov), X, x_mid, fov)
+x_to_α(T::Type, X, x_mid, fov) = (X + T(1e-3) - x_mid) / T(fov)
 
 """
     y_to_β(Y, y_mid, fov)
@@ -43,7 +44,8 @@ x_to_α(X, x_mid, fov) = (X + 1e-3 - x_mid) / fov
 Utility function for converting some `Y` on an image plane into ``\\beta``, given
 the midpoint `y_mid` and field-of-view multiplier `fov`.
 """
-y_to_β(Y, y_mid, fov) = (Y - y_mid) / fov
+y_to_β(Y, y_mid, fov) = y_to_β(typeof(fov), Y, y_mid, fov)
+y_to_β(T::Type, Y, y_mid, fov) = (Y - y_mid) / T(fov)
 
 function init_progress_bar(text, N, enabled)
     ProgressMeter.Progress(

--- a/src/special-radii.jl
+++ b/src/special-radii.jl
@@ -112,15 +112,15 @@ function _solve_radius_condition(
     select = maximum,
     resolution::Int = 100,
     θε::T = T(1e-7),
-    rmax = 5.0,
-    init = 0.0,
+    rmax = T(5.0),
+    init = T(0.0),
 ) where {T}
-    θs = range(θε, 2π - θε, resolution)
+    θs = range(θε, T(2π - θε), resolution)
     rs = map(θs) do θ
         f(r) = condition_function(m, r, θ)
         r = Roots.find_zeros(f, init, rmax)
         if isempty(r) || all(isnan, r)
-            NaN
+            T(NaN)
         else
             select(r)
         end

--- a/src/tracing/charts.jl
+++ b/src/tracing/charts.jl
@@ -53,16 +53,16 @@ function chart_for_metric(
     outer_radius = T(12000);
     closest_approach = T(1.01),
 ) where {T}
-    chart = PolarChart(inner_radius(m) * closest_approach, convert(T, outer_radius))
+    chart = PolarChart(inner_radius(m) * closest_approach, outer_radius)
     chart
 end
 
 function event_horizon_chart(
-    m::AbstractMetric;
-    outer_radius = 1200.0,
-    closest_approach = 1.01,
+    m::AbstractMetric{T};
+    outer_radius = T(12000),
+    closest_approach = T(1.01),
     kwargs...,
-)
+) where {T}
     rs, θs = event_horizon(m; kwargs...)
     shapefunc = DataInterpolations.LinearInterpolation(rs .* closest_approach, θs)
     PoloidalShapeChart(shapefunc, outer_radius)

--- a/src/tracing/configuration.jl
+++ b/src/tracing/configuration.jl
@@ -24,6 +24,7 @@ struct TracingConfiguration{
     λ_domain::Tuple{T,T}
     abstol::T
     reltol::T
+    verbose::Bool
     # constructor
     function TracingConfiguration(
         m::AbstractMetric{T},
@@ -39,6 +40,7 @@ struct TracingConfiguration{
         λ_max,
         abstol,
         reltol,
+        verbose,
     ) where {T,V}
         if V <: Function && isnothing(trajectories)
             error("When velocity is a function, trajectories must be defined.")
@@ -75,6 +77,7 @@ struct TracingConfiguration{
             (λ_min, λ_max),
             abstol,
             reltol,
+            verbose,
         )
     end
 end
@@ -93,6 +96,7 @@ end
     trajectories = nothing,
     abstol = 1e-9,
     reltol = 1e-9,
+    integrator_verbose = true,
     solver_opts...,
 ) where {D}
     _velocity, _trajectories = promote_velfunc(m, position, velocity, trajectories)
@@ -110,6 +114,7 @@ end
         D <: Number ? λs : λs[2],
         abstol,
         reltol,
+        integrator_verbose,
     )
     config, solver_opts
 end

--- a/src/tracing/geodesic-problem.jl
+++ b/src/tracing/geodesic-problem.jl
@@ -1,4 +1,3 @@
-
 struct IntegrationParameters{M} <: AbstractIntegrationParameters{M}
     metric::M
     status::MutStatusCode
@@ -77,11 +76,11 @@ function geodesic_ode_problem(
     )
 end
 
-function _second_order_ode_f(u::SVector{8,T}, p, λ) where {T}
-    @inbounds let x = SVector{4,T}(@view(u[1:4])), v = SVector{4,T}(@view(u[5:8]))
-        dv = SVector{4,T}(geodesic_equation(get_metric(p), x, v))
-        vcat(v, dv)
-    end
+function _second_order_ode_f(u::SVector{8}, p, λ)
+    x = @inbounds SVector{4}(view(u, 1:4))
+    v = @inbounds SVector{4}(view(u, 5:8))
+    dv = geodesic_equation(get_metric(p), x, v)
+    return vcat(v, dv)
 end
 
 """

--- a/src/tracing/method-implementations/auto-diff.jl
+++ b/src/tracing/method-implementations/auto-diff.jl
@@ -112,52 +112,28 @@ Limitations:
 - currenly pre-supposes static, axis-symmetric metric.
 """
 @generated function compute_geodesic_equation(
-    _ginv::SVector{5},
+    _ginv::SVector{5,T},
     _j1::SVector{5},
     _j2::SVector{5},
     _v::SVector{4},
-)
-    _compute_geodesic_equation(_ginv, _j1, _j2, _v)
-end
-# seperate the code generation for easier debugging
-function _compute_geodesic_equation(
-    _ginv::Type{<:SVector{5,T}},
-    _j1::Type{<:SVector{5}},
-    _j2::Type{<:SVector{5}},
-    _v::Type{<:SVector{4}},
 ) where {T}
     Symbolics.@variables ginv[1:5], j1[1:5], j2[1:5], v[1:4] # non zero metric components
-    inverse_metric = [
-        ginv[1] 0 0 ginv[5]
-        0 ginv[2] 0 0
-        0 0 ginv[3] 0
-        ginv[5] 0 0 ginv[4]
-    ]
-    j1_mat = [
-        j1[1] 0 0 j1[5]
-        0 j1[2] 0 0
-        0 0 j1[3] 0
-        j1[5] 0 0 j1[4]
-    ]
-    j2_mat = [
-        j2[1] 0 0 j2[5]
-        0 j2[2] 0 0
-        0 0 j2[3] 0
-        j2[5] 0 0 j2[4]
-    ]
+    inverse_metric = _symmetric_matrix(ginv)
+    j1_mat = _symmetric_matrix(j1)
+    j2_mat = _symmetric_matrix(j2)
     j0 = zeros(Symbolics.Num, (4, 4))
     jacobian = (j0, j1_mat, j2_mat, j0)
     # christoffel symbols
     @tullio Γ[i, k, l] :=
-        _float_type(T)(1 / 2) *
+        (1 / 2) *
         inverse_metric[i, m] *
         (jacobian[l][m, k] + jacobian[k][m, l] - jacobian[m][k, l])
     quote
         @inbounds @muladd @fastmath let ginv = _ginv, j1 = _j1, j2 = _j2, v = _v
-            Γ1 = SMatrix{4,4,$(T)}($(Symbolics.toexpr.(Γ[1, :, :])...))
-            Γ2 = SMatrix{4,4,$(T)}($(Symbolics.toexpr.(Γ[2, :, :])...))
-            Γ3 = SMatrix{4,4,$(T)}($(Symbolics.toexpr.(Γ[3, :, :])...))
-            Γ4 = SMatrix{4,4,$(T)}($(Symbolics.toexpr.(Γ[4, :, :])...))
+            Γ1 = SMatrix{4,4,T}($(Symbolics.toexpr.(Γ[1, :, :])...))
+            Γ2 = SMatrix{4,4,T}($(Symbolics.toexpr.(Γ[2, :, :])...))
+            Γ3 = SMatrix{4,4,T}($(Symbolics.toexpr.(Γ[3, :, :])...))
+            Γ4 = SMatrix{4,4,T}($(Symbolics.toexpr.(Γ[4, :, :])...))
 
             -SVector{4}((Γ1 * v) ⋅ v, (Γ2 * v) ⋅ v, (Γ3 * v) ⋅ v, (Γ4 * v) ⋅ v)
         end
@@ -253,12 +229,7 @@ end
 function metric(m::AbstractStaticAxisSymmetric, x::SVector{4})
     rθ = (x[2], x[3])
     comps = metric_components(m, rθ)
-    @SMatrix [
-        comps[1] 0 0 comps[5]
-        0 comps[2] 0 0
-        0 0 comps[3] 0
-        comps[5] 0 0 comps[4]
-    ]
+    _symmetric_matrix(comps)
 end
 
 export AbstractStaticAxisSymmetric

--- a/src/tracing/method-implementations/auto-diff.jl
+++ b/src/tracing/method-implementations/auto-diff.jl
@@ -149,7 +149,7 @@ function _compute_geodesic_equation(
     jacobian = (j0, j1_mat, j2_mat, j0)
     # christoffel symbols
     @tullio Γ[i, k, l] :=
-        (one(T) / 2) *
+        (1 / 2) *
         inverse_metric[i, m] *
         (jacobian[l][m, k] + jacobian[k][m, l] - jacobian[m][k, l])
     quote

--- a/src/tracing/method-implementations/auto-diff.jl
+++ b/src/tracing/method-implementations/auto-diff.jl
@@ -149,7 +149,7 @@ function _compute_geodesic_equation(
     jacobian = (j0, j1_mat, j2_mat, j0)
     # christoffel symbols
     @tullio Γ[i, k, l] :=
-        (1 / 2) *
+        _float_type(T)(1 / 2) *
         inverse_metric[i, m] *
         (jacobian[l][m, k] + jacobian[k][m, l] - jacobian[m][k, l])
     quote
@@ -163,6 +163,9 @@ function _compute_geodesic_equation(
         end
     end
 end
+
+_float_type(T::Type{<:AbstractFloat}) = T
+_float_type(::Type{ForwardDiff.Dual{<:ForwardDiff.Tag{F,T}}}) where {F,T} = T
 
 """
     constrain_time(g_comp, v, μ = 0.0, positive::Bool = true)

--- a/src/tracing/tracing.jl
+++ b/src/tracing/tracing.jl
@@ -142,7 +142,8 @@ function ensemble_solve_tracing_problem(
         reltol = config.reltol,
         solver_opts...,
         # throw error if wrong keyword arguments passed
-        kwargshandle = KeywordArgError,
+        # TODO: this should be only for the GPU ensemble dispatch
+        # kwargshandle = KeywordArgError,
     )
 end
 # thread reusing dispatch

--- a/src/tracing/tracing.jl
+++ b/src/tracing/tracing.jl
@@ -104,6 +104,7 @@ solve_tracing_problem(
         solver_opts...,
         # throw error if wrong keyword arguments passed
         kwargshandle = KeywordArgError,
+        verbose = config.verbose,
     )
     sol
 end
@@ -144,6 +145,7 @@ function ensemble_solve_tracing_problem(
         # throw error if wrong keyword arguments passed
         # TODO: this should be only for the GPU ensemble dispatch
         # kwargshandle = KeywordArgError,
+        verbose = config.verbose,
     )
 end
 # thread reusing dispatch
@@ -167,6 +169,7 @@ end
             solver = config.solver,
             abstol = config.abstol,
             reltol = config.reltol,
+            verbose = config.verbose,
             save_on = save_on,
             solver_opts...,
         ),
@@ -198,6 +201,7 @@ end
     abstol = 1e-9,
     reltol = 1e-9,
     save_on = true,
+    verbose = true,
     solver_opts...,
 )
     SciMLBase.init(
@@ -209,6 +213,7 @@ end
         solver_opts...,
         # throw error if wrong keyword arguments passed
         kwargshandle = KeywordArgError,
+        verbose = verbose,
     )
 end
 
@@ -222,7 +227,7 @@ end
 ) where {T}
     config, solver_opts = tracing_configuration(trace, m, args...; kwargs...)
     problem = assemble_tracing_problem(trace, config)
-    _init_integrator(problem; solver_opts...)
+    _init_integrator(problem; verbose = config.verbose, solver_opts...)
 end
 
 

--- a/src/tracing/tracing.jl
+++ b/src/tracing/tracing.jl
@@ -136,15 +136,14 @@ function ensemble_solve_tracing_problem(
     solve(
         prob,
         config.solver,
-        config.ensemble,
+        ensemble,
         ;
         trajectories = config.trajectories,
         abstol = config.abstol,
         reltol = config.reltol,
         solver_opts...,
         # throw error if wrong keyword arguments passed
-        # TODO: this should be only for the GPU ensemble dispatch
-        # kwargshandle = KeywordArgError,
+        kwargshandle = KeywordArgError,
         verbose = config.verbose,
     )
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,6 +2,15 @@ function _make_interpolation(x, y)
     DataInterpolations.LinearInterpolation(y, x)
 end
 
+@inline function _symmetric_matrix(comps::AbstractVector{T})::SMatrix{4,4,T} where {T}
+    @SMatrix [
+        comps[1] 0 0 comps[5]
+        0 comps[2] 0 0
+        0 0 comps[3] 0
+        comps[5] 0 0 comps[4]
+    ]
+end
+
 @inline function _threaded_map(f, itr::T) where {T}
     N = length(itr)
     items = !(T <: AbstractArray) ? collect(itr) : itr


### PR DESCRIPTION
Closes #8 

There's still a lot of work to do here:
- [x] properly embed the GPU ensemble calls into the tracing pipeline to ensure e.g. `kwargshandle` isn't passed to `solve`, and that the `dt` / `adaptive` is set correctly
- [x] investigate why GPU tracing is returning poor trajectories
- [x] bundle into an Extra package that loads if the user also is using DiffEqGPU.jl (Julia 1.9 feature)
- [x] fix type promotion issues with using GPU in `rendergeodesics`
- [ ] batch solve non-deterministically fails

This PR currently includes a temporary fix for handling sin / cos duals in ForwardDiff when dispatching on Metal.

### State of the device

Rudimentary benchmarks look very promising (fully Float32):
```julia
sols = @btime tracegeodesics(m, us, vs, 2000.0f0)
# 100:      13.175 ms (98917 allocations: 38.06 MiB)
# 10_000:   1.727 s (9873983 allocations: 3.72 GiB)

sols = @btime tracegeodesics(m, us, vs, 2000.0f0,
    solver = GPUTsit5(), ensemble = EnsembleGPUKernel(Metal.MetalBackend())
)
# 100:      31.596 ms (3095 allocations: 2.17 MiB)
# 10_000:   231.454 ms (187074 allocations: 204.85 MiB)
```

However, the traces themselves do not. On the CPU, we get:
<img width="505" alt="Screenshot 2023-07-30 at 22 53 42" src="https://github.com/astro-group-bristol/Gradus.jl/assets/11492844/680e43b2-811e-49da-8ce6-88ec26c390aa">

Whereas on the GPU:
<img width="506" alt="Screenshot 2023-07-30 at 22 53 48" src="https://github.com/astro-group-bristol/Gradus.jl/assets/11492844/84f202a7-efb0-4b68-b404-791eadcde660">

Clearly there is something very wrong here. Since the impact parameters are set for $\alpha$ between 5 and 10, the lack of spread in the GPU picture might suggest that the initial steps of the integrator are poor, which then propagates further into the integration. 

The performance is promising, and provided it doesn't degrade in trying to fix the numerical issues, then the GPU support should be very worthwhile.



