### PR TITLE
Fix: try to improve the visibility criteria

### DIFF
--- a/src/corona/samplers.jl
+++ b/src/corona/samplers.jl
@@ -63,6 +63,14 @@ function _cart_to_spher_jacobian(θ, ϕ)
     ]
 end
 
+function _spher_to_cart_jacobian(θ, ϕ, r)
+    @SMatrix [
+        sin(θ)*cos(ϕ) r*cos(θ)*cos(ϕ) -r*sin(θ)*sin(ϕ)
+        sin(θ)*sin(ϕ) r*cos(θ)*sin(ϕ) r*sin(θ)*cos(ϕ)
+        cos(θ) -r*sin(θ) 0
+    ]
+end
+
 function _cart_local_direction(θ, ϕ)
     @SVector [sin(θ) * cos(ϕ), sin(θ) * sin(ϕ), cos(θ)]
 end

--- a/src/geometry/discs.jl
+++ b/src/geometry/discs.jl
@@ -45,7 +45,7 @@ end
 cross_section(d::AbstractThickAccretionDisc, x4) =
     error("Not implemented for $(typeof(d)).")
 r_cross_section(d::AbstractThickAccretionDisc, r::Number) =
-    cross_section(d, SVector(0.0, r, π / 2, 0.0))
+    cross_section(d, SVector(0, r, π / 2, 0))
 
 struct EllipticalDisc{T} <: AbstractAccretionDisc{T}
     inner_radius::T

--- a/src/geometry/discs/thick-disc.jl
+++ b/src/geometry/discs/thick-disc.jl
@@ -61,5 +61,27 @@ function distance_to_disc(d::AbstractThickAccretionDisc, x4; gtol)
     abs(z) - height - (gtol * x4[2])
 end
 
+function _cartesian_tangent_vector(ρ, d::AbstractThickAccretionDisc)
+    function _parameterization(r)
+        xz_parameterize(d, r)
+    end
+    ∇f = ForwardDiff.derivative(_parameterization, ρ)
+    v = SVector(∇f[1], 0, ∇f[2])
+    v ./ √(v[1]^2 + v[2]^2 + v[3]^2)
+end
+
+function _cartesian_surface_normal(ρ, d::AbstractThickAccretionDisc)
+    ∇f = _cartesian_tangent_vector(ρ, d)
+    # rotate 90 degrees in about ϕ̂
+    SVector(-∇f[3], ∇f[2], ∇f[1])
+end
+
+function _rotate_cartesian_about_z(n, ϕ)
+    SVector(n[1] * cos(ϕ), n[1] * sin(ϕ), n[3])
+end
+
+function _cartesian_surface_normal(ρ, ϕ, d::AbstractThickAccretionDisc)
+    _rotate_cartesian_about_z(_cartesian_surface_normal(ρ, d), ϕ)
+end
 
 export ThickDisc

--- a/src/plotting-recipes.jl
+++ b/src/plotting-recipes.jl
@@ -1,7 +1,14 @@
 using RecipesBase
 
-function _extract_path(sol, n_points; projection = :none, t_span = 100.0)
-    mid_i = max(1, length(sol.u) ÷ 2)
+function _extract_path(sol, n_points; projection = :none, t_span = 30.0)
+    status = Gradus.get_status_code(sol.prob.p)
+    mid_i =
+        if (status == StatusCodes.IntersectedWithGeometry) ||
+           (status == StatusCodes.WithinInnerBoundary)
+            lastindex(sol.t)
+        else
+            max(1, length(sol.u) ÷ 2)
+        end
 
     start_t = max(sol.t[mid_i] - t_span, sol.t[1])
     end_t = min(sol.t[mid_i] + t_span, sol.t[end])
@@ -31,13 +38,13 @@ end
     zlims --> _range
     aspect_ratio --> 1
 
-    itr = if !(typeof(sol) <: SciMLBase.EnsembleSolution)
-        (; u = (sol,))
+    itr = if typeof(sol) <: SciMLBase.EnsembleSolution
+        sol.u
     else
         sol
     end
 
-    for s in itr.u
+    for s in itr
         path = _extract_path(s, n_points, projection = :none, t_span = t_span)
         @series begin
             path

--- a/src/solution-processing.jl
+++ b/src/solution-processing.jl
@@ -114,6 +114,7 @@ function unpack_solution_full(
             ui = SVector{4,T}(us[i][1:4])
             vi = SVector{4,T}(us[i][5:8])
             ti = ts[i]
+            aux = unpack_auxiliary(us[i])
             GeodesicPoint(
                 get_status_code(sol.prob.p),
                 t_start,
@@ -122,6 +123,7 @@ function unpack_solution_full(
                 ui,
                 v_start,
                 vi,
+                aux,
             )
         end
     end

--- a/src/transfer-functions/cunningham-transfer-functions.jl
+++ b/src/transfer-functions/cunningham-transfer-functions.jl
@@ -187,15 +187,15 @@ function _rear_workhorse_with_impact_parameters(
             redshift_pf = redshift_pf,
             tracer_kwargs...,
         )
-        (g, J, gp.x[1], α, β)
+        (g, J, gp, α, β)
     end
     (_workhorse, tracer_kwargs)
 end
 function _rear_workhorse(m::AbstractMetric, x, d::AbstractAccretionDisc, rₑ; kwargs...)
     workhorse, _ = _rear_workhorse_with_impact_parameters(m, x, d, rₑ; kwargs...)
     function _disc_workhorse(θ::T)::NTuple{3,T} where {T}
-        g, J, t, _, _ = workhorse(θ)
-        g, J, t
+        g, J, gp, _, _ = workhorse(θ)
+        g, J, gp.x[1]
     end
 end
 
@@ -205,7 +205,6 @@ function _rear_workhorse(
     d::AbstractThickAccretionDisc,
     rₑ;
     max_time = 2 * x[2],
-    visible_tolerance = 1e-3,
     kwargs...,
 )
     plane = datumplane(d, rₑ)
@@ -217,45 +216,12 @@ function _rear_workhorse(
         max_time = max_time,
         kwargs...,
     )
+    n = _cartesian_surface_normal(rₑ, d)
     function _thick_workhorse(θ::T)::NTuple{4,T} where {T}
-        g, J, t, α, β = datum_workhorse(θ)
-        # check if the location is visible or not
-        is_visible = _trace_is_visible(
-            m,
-            x,
-            α,
-            β,
-            d,
-            rₑ;
-            visible_tolerance = visible_tolerance,
-            tracer_kwargs...,
-        )
-        (g, J, t, is_visible)
+        g, J, gp, _, _ = datum_workhorse(θ)
+        is_visible = _is_visible(m, d, gp, n)
+        (g, J, gp.x[1], is_visible)
     end
-end
-
-function _trace_is_visible(
-    m,
-    x,
-    α,
-    β,
-    d,
-    rₑ;
-    max_time = 2x[2],
-    visible_tolerance = 1e-3,
-    kwargs...,
-)
-    sol = tracegeodesics(
-        m,
-        x,
-        map_impact_parameters(m, x, α, β),
-        d,
-        max_time;
-        save_on = false,
-        kwargs...,
-    )
-    gp = unpack_solution(sol)
-    abs(rₑ - _equatorial_project(gp.x)) < visible_tolerance
 end
 
 function _cunningham_transfer_function!(

--- a/src/transfer-functions/cunningham-transfer-functions.jl
+++ b/src/transfer-functions/cunningham-transfer-functions.jl
@@ -147,11 +147,12 @@ function _rear_workhorse_with_impact_parameters(
     d::AbstractAccretionDisc,
     rₑ;
     max_time = 2 * x[2],
-    redshift_pf = ConstPointFunctions.redshift(m, x),
     offset_max = 0.4rₑ + 10,
     zero_atol = 1e-7,
     β₀ = 0,
     α₀ = 0,
+    redshift_pf = ConstPointFunctions.redshift(m, x),
+    jacobian_disc = d,
     tracer_kwargs...,
 )
     function _workhorse(θ)
@@ -180,7 +181,7 @@ function _rear_workhorse_with_impact_parameters(
         J = jacobian_∂αβ_∂gr(
             m,
             x,
-            d,
+            jacobian_disc,
             α,
             β,
             max_time;
@@ -214,6 +215,7 @@ function _rear_workhorse(
         plane,
         rₑ;
         max_time = max_time,
+        jacobian_disc = d,
         kwargs...,
     )
     n = _cartesian_surface_normal(rₑ, d)

--- a/test/transfer-functions/test-thick-disc.jl
+++ b/test/transfer-functions/test-thick-disc.jl
@@ -8,4 +8,4 @@ d = ShakuraSunyaev(m)
 tf = cunningham_transfer_function(m, x, d, 3.0; β₀ = 1.0)
 
 total = sum(filter(!isnan, tf.f))
-@test total ≈ 13.419539069804333 atol = 1e-4
+@test total ≈ 12.148257594740231 atol = 1e-4


### PR DESCRIPTION
Basically, the conclusion of investigating #160 is that the root finder thinks it can see emission radii that are actually obscured. It's amazing just how big of an impact this really has, but tweaking the old visibility tolerance parameter helped the two curves line up in places. So it's clear we need a better visibility criteria: the question is just what?

I tried to make the `_is_visible` function more robust in this PR. Instead of just checking the proximity of a trajectory, traced with the full thick disc, to the target emission radius (which is biased towards concluding visible at small radii), the first simple change is to check the Cartesian distance between the target point and the geodesic endpoint.

This isn't however always enough, and requires recomputing the geodesic too (which should be treated at the $< \epsilon$ level as probabilistic). Another method that I have tried is to compute the vector normal to the surface of the disc via automatic differentiation, and then check if the velocity vector at the endpoint of the geodesic, $\vec{v}$, satisfies

$$
\vec{n} \cdot \vec{v} < 0
$$ 

as a visibility critera. Since both tangent vectors belong to the same space of forms in the Kerr spacetime, the tangent space can be treated as locally Euclidean (Minkowski), and therefore this is equivalent to asking whether the geodesic came from behind the disc or not.

However, neither of these two things (seperately or in tandem) are enough to correct the lineprofile differences. The state is slightly improved, and by tweaking tolerances once can more or less force the line profiles to become very similar, albeit noisy, just as before. 

This introduces a slightly metaphysical question however: if we regard the transfer funciton method as equivalent to an image with infinite resolution, then it will be able to see small patches of the disc that our finite resolution render will not. Are these emissions physical? Should these flux contributions be included, and the binning method disregarded as unable to appropriately evaluate in the limit of infinite resolution? Or do we conclude that the transfer function method is giving too much weight to portions of the disc that would lend miniscule contributions to the overall flux profile?

I am still unable to decide which of the two methods is "correct". And although we have _discovered the bug_, it is unsatisfying that an improved visibility criteria is unable to improve the lineprofiles unless the visibility criteria lends myopia to the method. It's kind of like saying "yes, the transfer function method agrees, but only if you or the algorithm squint". 



