### PR TITLE
Another attempt at some transfer function fixes

### DIFF
--- a/src/transfer-functions/cunningham-transfer-functions.jl
+++ b/src/transfer-functions/cunningham-transfer-functions.jl
@@ -1,4 +1,4 @@
-const JACOBIAN_THICK_DISC_TOLERANCE = 1e-11
+const JACOBIAN_THICK_DISC_TOLERANCE = 1e-13
 
 struct _TransferFunctionSetup{T}
     h::T
@@ -239,7 +239,7 @@ function _rear_workhorse(
     kwargs...,
 )
     plane = datumplane(d, rₑ)
-    datum_workhorse, tracer_kwargs = _rear_workhorse_with_impact_parameters(
+    datum_workhorse, _ = _rear_workhorse_with_impact_parameters(
         setup,
         m,
         x,

--- a/test/transfer-functions/test-thick-disc.jl
+++ b/test/transfer-functions/test-thick-disc.jl
@@ -8,4 +8,4 @@ d = ShakuraSunyaev(m)
 tf = cunningham_transfer_function(m, x, d, 3.0; β₀ = 1.0)
 
 total = sum(filter(!isnan, tf.f))
-@test total ≈ 12.148257594740231 atol = 1e-4
+@test total ≈ 12.27895052104429 atol = 1e-4


### PR DESCRIPTION
I actually had a really cool idea for this one:

$$
\left\lvert \frac{\partial r }{ \partial r_\text{e}} \right\rvert = \lvert \sin\theta \rvert^{-1}, 
$$

and then

$$
\left\lvert \frac{\partial(\alpha, \ \beta)}{\partial(r_\text{e}, \ g^\ast)} 
\right\rvert = 
\left\lvert 
\frac{\partial(\alpha, \ \beta)}{\partial(r, \ g^\ast)}
\right\rvert \left\lvert \frac{\partial r }{ \partial r_\text{e}} \right\rvert.
$$

Cool huh? Especially since in general $\delta r > \delta r_\text{e}$.

Well, $\lvert \partial h  / \partial r_\text{e} \rvert$ can be evaluated with AD from the cross section function, and then we can do 

$$
\left\lvert \frac{\partial(\alpha, \ \beta)}{\partial(r_\text{e}, \ g^\ast)} 
\right\rvert = 
\left\lvert 
\frac{\partial(\alpha, \ \beta)}{\partial(h, \ g^\ast)}
\right\rvert \left\lvert \frac{\partial h}{ \partial r} \right\rvert,
$$

which works really well at those fiddly small radii, since now $\delta h >> \delta r_\text{e}$, and the Jacobian integrator tolerances can be set to something more or less sensible again.

Performance of the transfer functions really needs to be added to a benchmark suite to make sure this kind of stuff doesn't cause regressions.
