### PR TITLE
Add extrapolation to orbit-solving interpolation

### DIFF
--- a/src/corona/profiles/analytic.jl
+++ b/src/corona/profiles/analytic.jl
@@ -16,10 +16,22 @@ function AnalyticRadialDiscProfile(emissivity, cg::CoronaGeodesics)
     AnalyticRadialDiscProfile(emissivity, t)
 end
 
-emissivity_at(prof::AnalyticRadialDiscProfile, r::Number) = prof.ε(r)
+function emissivity_at(prof::AnalyticRadialDiscProfile, r::Number)
+    r_bounded = _enforce_interpolation_bounds(r, prof)
+    prof.ε(r)
+end
 emissivity_at(prof::AnalyticRadialDiscProfile, gp::AbstractGeodesicPoint) =
     emissivity_at(prof, _equatorial_project(gp.x))
 
-coordtime_at(prof::AnalyticRadialDiscProfile, r::Number) = prof.t(r)
+function coordtime_at(prof::AnalyticRadialDiscProfile, r::Number)
+    r_bounded = _enforce_interpolation_bounds(r, prof)
+    prof.t(r_bounded)
+end
 coordtime_at(prof::AnalyticRadialDiscProfile, gp::AbstractGeodesicPoint) =
     coordtime_at(prof, _equatorial_project(gp.x)) + gp.x[1]
+
+function _enforce_interpolation_bounds(r::Number, prof::AnalyticRadialDiscProfile)
+    r_min = first(prof.t.t)
+    r_max = last(prof.t.t)
+    _enforce_interpolation_bounds(r, r_min, r_max)
+end

--- a/src/corona/profiles/radial.jl
+++ b/src/corona/profiles/radial.jl
@@ -6,11 +6,23 @@ struct RadialDiscProfile{T,I} <: AbstractDiscProfile
     interp_t::I
 end
 
-emissivity_at(prof::RadialDiscProfile, r::Number) = prof.interp_ε(r)
+@inline function _enforce_interpolation_bounds(r::Number, prof::RadialDiscProfile)
+    r_min = first(prof.radii)
+    r_max = last(prof.radii)
+    return _enforce_interpolation_bounds(r, r_min, r_max)
+end
+
+function emissivity_at(prof::RadialDiscProfile, r::Number)
+    r_bounded = _enforce_interpolation_bounds(r, prof)
+    prof.interp_ε(r_bounded)
+end
 emissivity_at(prof::RadialDiscProfile, gp::AbstractGeodesicPoint) =
     emissivity_at(prof, _equatorial_project(gp.x))
 
-coordtime_at(prof::RadialDiscProfile, r::Number) = prof.interp_t(r)
+function coordtime_at(prof::RadialDiscProfile, r::Number)
+    r_bounded = _enforce_interpolation_bounds(r, prof)
+    prof.interp_t(r_bounded)
+end
 coordtime_at(prof::RadialDiscProfile, gp::AbstractGeodesicPoint) =
     coordtime_at(prof, _equatorial_project(gp.x)) + gp.x[1]
 

--- a/src/orbits/orbit-solving.jl
+++ b/src/orbits/orbit-solving.jl
@@ -112,13 +112,13 @@ struct PlungingInterpolation{M,_interp_type}
         vr = sol[6, :][I]
         vϕ = sol[8, :][I]
 
-        rinterp = DataInterpolations.LinearInterpolation(vt, r)
+        rinterp = DataInterpolations.LinearInterpolation(vt, r; extrapolate=true)
 
         new{M,typeof(rinterp)}(
             m,
             rinterp,
-            DataInterpolations.LinearInterpolation(vr, r),
-            DataInterpolations.LinearInterpolation(vϕ, r),
+            DataInterpolations.LinearInterpolation(vr, r; extrapolate=true),
+            DataInterpolations.LinearInterpolation(vϕ, r; extrapolate=true),
         )
     end
 end

--- a/src/transfer-functions/transfer-functions-2d.jl
+++ b/src/transfer-functions/transfer-functions-2d.jl
@@ -174,21 +174,21 @@ function lagtransfer(
 end
 
 function binflux(tf::LagTransferFunction; kwargs...)
-    profile = AnalyticRadialDiscProfile(r -> r^-3, tf.emissivity_profile)
+    profile = AnalyticRadialDiscProfile(r -> r^-3, tf.coronal_geodesics)
     binflux(tf, profile; kwargs...)
 end
 
 function binflux(
     tf::LagTransferFunction,
     profile::AbstractDiscProfile;
-    redshift = ConstPointFunctions.redshift(tf.emissivity_profile.metric, tf.x),
+    redshift = ConstPointFunctions.redshift(tf.coronal_geodesics.metric, tf.x),
     E₀ = 6.4,
     t0 = tf.x[2],
     kwargs...,
 )
     t = coordtime_at(profile, tf.observer_to_disc)
     ε = emissivity_at(profile, tf.observer_to_disc)
-    g = redshift.(tf.emissivity_profile.metric, tf.observer_to_disc, tf.max_t)
+    g = redshift.(tf.coronal_geodesics.metric, tf.observer_to_disc, tf.max_t)
     # calculate flux
     f = @. g^3 * ε * tf.image_plane_areas
     # normalize

--- a/src/transfer-functions/types.jl
+++ b/src/transfer-functions/types.jl
@@ -32,17 +32,17 @@ struct LagTransferFunction{T,X,E,P}
     max_t::T
     x::X
     image_plane_areas::Vector{T}
-    emissivity_profile::E
+    coronal_geodesics::E
     observer_to_disc::Vector{P}
 end
 
 function Base.show(io::IO, ::MIME"text/plain", tf::LagTransferFunction)
-    text = """LagTransferFunction for $(typeof(tf.emissivity_profile.metric)) 
+    text = """LagTransferFunction for $(typeof(tf.coronal_geodesics.metric)) 
       . observer position      
           $(tf.x)
-      . model                         : $(typeof(tf.emissivity_profile.model))
+      . model                         : $(typeof(tf.coronal_geodesics.model))
       . observer to disc photon count : $(length(tf.observer_to_disc))
-      . source to disc photon count   : $(length(tf.emissivity_profile.geodesic_points))
+      . source to disc photon count   : $(length(tf.coronal_geodesics.geodesic_points))
       Total memory: $(Base.format_bytes(Base.summarysize(tf)))
     """
     print(io, text)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -36,6 +36,13 @@ function _make_interpolation(x, y)
     DataInterpolations.LinearInterpolation(y, x)
 end
 
+@inline function _enforce_interpolation_bounds(r::Number, r_min::Number, r_max::Number)
+    if (r < r_min) || (r > r_max)
+        @warn "Interpolation out of bounds $r ∉ [$(r_min),  $(r_max)]. Additional geodesic samples may be required."
+    end
+    clamp(r, r_min, r_max)
+end
+
 @inline function _linear_interpolate(y1, y2, θ)
     (1 - θ) * y1 + θ * y2
 end

--- a/test/transfer-functions/test-2d.jl
+++ b/test/transfer-functions/test-2d.jl
@@ -23,7 +23,7 @@ tf = lagtransfer(
 
 # check number of intersection points
 @test length(tf.observer_to_disc) == 335
-@test length(tf.emissivity_profile.geodesic_points) == 58
+@test length(tf.coronal_geodesics.geodesic_points) == 58
 
 # ensure binning works as expected
 t, E, f = binflux(tf, N_t = 100, N_E = 100)


### PR DESCRIPTION
This pull request adds extrapolation to the orbit-solving interpolation. The `extrapolate=true` argument has been added to the `LinearInterpolation` function calls in the `PlungingInterpolation` struct.