### PR TITLE
Fix: most of the problems with a co-rotating extended corona

### DIFF
--- a/src/corona/emissivity.jl
+++ b/src/corona/emissivity.jl
@@ -167,11 +167,12 @@ function emissivity_profile(
     )
 end
 
-function _proper_area(m, x::SVector{4})
-    gcomp = Gradus.metric_components(m, SVector(x[2], x[3]))
+function _proper_area(m::AbstractMetric, r::Number, θ::Number)
+    gcomp = Gradus.metric_components(m, SVector(r, θ))
     det_g = √(gcomp[2] * gcomp[4])
     2π * det_g
 end
+_proper_area(m::AbstractMetric, x::SVector{4}) = _proper_area(m, x[2], x[3])
 
 function polar_angle_to_velfunc(m::AbstractMetric, x, v, δs; ϕ = zero(eltype(x)))
     function _polar_angle_velfunc(i)

--- a/src/corona/models/extended.jl
+++ b/src/corona/models/extended.jl
@@ -141,7 +141,13 @@ end
 
 function _process_ring_traces(setup::EmissivityProfileSetup, m, d, v, gps, rs, δs)
     # no need to filter intersected, as we have already done that before calling this process function
-    J = sortperm(rs)
+    J = sortperm(δs)
+
+    J = unique(i -> rs[i], J)
+    # now need to find the cycle permutation to make the minimal radius the first element
+    _, index = findmax(i -> rs[i], J)
+    J = vcat(J[index+1:end], J[1:index-1])
+
     points = gps[J]
     δs_sorted = δs[J]
     r, ε = _point_source_emissivity(m, d, setup.spectrum, v, rs[J], δs_sorted, points)

--- a/src/corona/models/extended.jl
+++ b/src/corona/models/extended.jl
@@ -141,13 +141,7 @@ end
 
 function _process_ring_traces(setup::EmissivityProfileSetup, m, d, v, gps, rs, δs)
     # no need to filter intersected, as we have already done that before calling this process function
-    J = sortperm(δs)
-
-    J = unique(i -> rs[i], J)
-    # now need to find the cycle permutation to make the minimal radius the first element
-    _, index = findmax(i -> rs[i], J)
-    J = vcat(J[index+1:end], J[1:index-1])
-
+    J = sortperm(rs)
     points = gps[J]
     δs_sorted = δs[J]
     r, ε = _point_source_emissivity(m, d, setup.spectrum, v, rs[J], δs_sorted, points)

--- a/src/corona/models/extended.jl
+++ b/src/corona/models/extended.jl
@@ -144,9 +144,10 @@ function _process_ring_traces(setup::EmissivityProfileSetup, m, d, v, gps, rs, �
     J = sortperm(rs)
     points = gps[J]
     δs_sorted = δs[J]
-    r, ε = _point_source_emissivity(m, d, setup.spectrum, v, rs[J], δs_sorted, points)
-    t = [i.x[1] for i in @views(points[1:(end-1)])]
-    (; t, r, ε = abs.(ε))
+
+    r, ε, g = _point_source_emissivity(m, d, setup.spectrum, v, rs[J], δs_sorted, points)
+    t = [i.x[1] for i in points]
+    (; t, r, ε = abs.(ε), θ = δs_sorted, g)
 end
 
 # TODO: refactor the time-integration to make things like below possible without copy pasting the function

--- a/src/corona/models/lamp-post.jl
+++ b/src/corona/models/lamp-post.jl
@@ -70,7 +70,7 @@ as the PDF that samples ``\\theta`` uniformly.
 Dauser et al. (2013)
 """
 function point_source_equatorial_disc_emissivity(spec::AbstractCoronalSpectrum, θ, g, A, γ)
-    sin(θ) * coronal_spectrum(spec, g) / (A * γ)
+    abs(sin(θ)) * coronal_spectrum(spec, g) / (A * γ)
 end
 
 

--- a/src/corona/models/lamp-post.jl
+++ b/src/corona/models/lamp-post.jl
@@ -109,7 +109,7 @@ function _point_source_symmetric_emissivity_profile(
     points = points[J]
     δs = δs[J]
 
-    r, ε = _point_source_emissivity(m, d, setup.spectrum, v, rs_sorted, δs, points)
+    r, ε, _ = _point_source_emissivity(m, d, setup.spectrum, v, rs_sorted, δs, points)
     t = [i.x[1] for i in points]
 
     RadialDiscProfile(r, t, ε)
@@ -127,10 +127,13 @@ function _point_source_emissivity(
     # function for obtaining keplerian velocities
     _disc_velocity = _keplerian_velocity_projector(m, d)
 
+    all_g = Vector{T}(undef, length(points))
     ε = map(enumerate(points)) do (i, p)
         v_disc = _disc_velocity(p.x)
         gs = energy_ratio(m, p, source_velocity, v_disc)
         γ = lorentz_factor(m, p.x, v_disc)
+
+        all_g[i] = gs
 
         i1, i2, i3, i4 = if i == 1
             1, 2, 1, 2
@@ -147,7 +150,7 @@ function _point_source_emissivity(
         weight * point_source_equatorial_disc_emissivity(spec, δs[i], gs, A, γ)
     end
 
-    r, ε
+    r, ε, all_g
 end
 
 function emissivity_profile(

--- a/src/corona/models/ring.jl
+++ b/src/corona/models/ring.jl
@@ -658,22 +658,22 @@ function arrange_slice!(
     m::AbstractMetric,
     d::AbstractAccretionDisc,
 )
-    all_angles, all_gps = unpack_traces(cache)
+    _all_angles, _all_gps = unpack_traces(cache)
 
     # calculate the projected radial coordinate into the buffer
-    for (i, gp) in enumerate(all_gps)
+    for (i, gp) in enumerate(_all_gps)
         cache._buffer[i] = _equatorial_project(gp.x)
     end
-    all_rs = cache._buffer[1:length(all_gps)]
+    _all_rs = cache._buffer[1:length(_all_gps)]
 
-    J = sortperm(all_angles)
+    J = sortperm(_all_angles)
+    unique!(i -> _all_rs[i], J)
 
-    permute!(all_angles, J)
-    permute!(all_rs, J)
-    permute!(all_gps, J)
+    all_angles = _all_angles[J]
+    all_rs = _all_rs[J]
+    all_gps = _all_gps[J]
 
     # TODO: do we really need uniqueness here?
-    # unique!(i -> all_rs[i], J)
 
     # function for obtaining keplerian velocities
     _disc_velocity = _keplerian_velocity_projector(m, d)
@@ -692,7 +692,7 @@ function arrange_slice!(
     # mask the traces that didn't hit the disc
     # but not on angles, since we use those for interpolating
     @. gs[!mask] = all_rs[!mask] = ts[!mask] = gammas[!mask] = NaN
-    PointSlice(copy(all_angles), gs, gammas, copy(all_rs), ts)
+    PointSlice(all_angles, gs, gammas, all_rs, ts)
 end
 
 """

--- a/src/corona/models/ring.jl
+++ b/src/corona/models/ring.jl
@@ -279,10 +279,11 @@ end
 function _split_arms_indices(angles, ρs)
     # split the sky into a left and right side, such that each side has strictly
     # sortable and monotonic r as a function of θ on the local sky
-    _, min_ρ_index = findmin(ρs)
-    _, max_ρ_index = findmax(ρs)
+    _, _min_ρ_index = findmin(ρs)
+    _, _max_ρ_index = findmax(ρs)
 
-    min_ρ_index, max_ρ_index = min(min_ρ_index, max_ρ_index), max(min_ρ_index, max_ρ_index)
+    min_ρ_index, max_ρ_index =
+        min(_min_ρ_index, _max_ρ_index), max(_min_ρ_index, _max_ρ_index)
 
     r1 = vcat(collect(max_ρ_index+1:lastindex(ρs)), collect(1:min_ρ_index-1))
     r2 = collect(min_ρ_index:max_ρ_index)

--- a/src/corona/models/ring.jl
+++ b/src/corona/models/ring.jl
@@ -285,7 +285,7 @@ function _split_arms_indices(angles, ρs)
     min_ρ_index, max_ρ_index =
         min(_min_ρ_index, _max_ρ_index), max(_min_ρ_index, _max_ρ_index)
 
-    r1 = vcat(collect(max_ρ_index+1:lastindex(ρs)), collect(1:min_ρ_index-1))
+    r1 = vcat(collect(1:min_ρ_index-1), collect(max_ρ_index+1:lastindex(ρs)))
     r2 = collect(min_ρ_index:max_ρ_index)
 
     r1, r2

--- a/src/corona/models/ring.jl
+++ b/src/corona/models/ring.jl
@@ -477,9 +477,7 @@ end
 Computes the angular difference between two angles using modulo arithmetic.
 """
 function ang_diff(a1, a2)
-    b1 = a1 > π / 2 ? π - (a1 % π) : a1
-    b2 = a2 > π / 2 ? π - (a2 % π) : a2
-    abs(b1 - b2)
+    abs((a1 - a2 + π) / (2π) - π)
 end
 """
     PointSlice

--- a/src/corona/models/ring.jl
+++ b/src/corona/models/ring.jl
@@ -195,7 +195,7 @@ function _golden_bracket!(
         d_gp, d_value = _objective(d)
 
         if comparator(c_value, d_value)
-            if (c_value != best_estimate)
+            if comparator(c_value, best_estimate)
                 n += 1
                 _add_to_cache!(cache, c, c_gp)
             elseif too_many_iters
@@ -203,7 +203,7 @@ function _golden_bracket!(
             end
             b = d
         else
-            if (d_value != best_estimate)
+            if comparator(d_value, best_estimate)
                 n += 1
                 _add_to_cache!(cache, d, d_gp)
             elseif too_many_iters


### PR DESCRIPTION
How it escaped my attention in the past is beyond me, but apparently we had only been computing stationary extended coronae. When the corona is co-rotating, loads of problems entered because the assumptions I'd made turned out no longer to be true. 

This PR finalises some work I'd been doing in the last few weeks on rectifying that problem, and implements a brand new technique for interpolating emissivity functions quickly.

For consistently high resolution results (1 to 1000 rg with 2000 bins) even with edge case parameters, it takes about 1500 * 400 geodesics (~30 seconds of runtime on my laptop) for each ring used in the approximation.

For decent results for most of the parameter space, 1000 * 150 geodesics (~8 ish seconds) are sufficient. 

These numbers are still much higher than I'd like, and there is still plenty of room for optimisation, but this marks significant progress in fixing that oversight.

There is plenty of unused code in this PR that I will clean up later when I implement the test cases, as I am still using it for some consistency tests. 